### PR TITLE
Implement Switch and Redirect components

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ export const Route = props => {
   const { children, path } = props;
   const [matches, params] = useRoute(props.path);
 
-  if (!matches) {
+  if (!matches && !props.match) {
     return null;
   }
 
@@ -131,7 +131,7 @@ export const Switch = ({ children, location }) => {
   // https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Switch.js
   Children.forEach(children, child => {
     if (!element && isValidElement(child)) {
-      const [match] = matcher(child.props.path, originalLocation || location);
+      const [match] = matcher(child.props.path, location || originalLocation);
       if (match) element = child;
     }
   });

--- a/index.js
+++ b/index.js
@@ -139,4 +139,11 @@ export const Switch = ({ children, location }) => {
   return element ? cloneElement(element, { match: true }) : null;
 };
 
+export const Redirect = props => {
+  const router = useRouter();
+  useEffect(() => router.history.push(prop.href || props.to));
+
+  return null;
+};
+
 export default useRoute;

--- a/test/redirect.test.js
+++ b/test/redirect.test.js
@@ -1,0 +1,9 @@
+import React from "react";
+import TestRenderer from "react-test-renderer";
+
+import { Redirect } from "../index.js";
+
+it("renders nothing", () => {
+  const rendered = TestRenderer.create(<Redirect to="/users" />).root;
+  expect(rendered.children.length).toBe(0);
+});

--- a/test/switch.test.js
+++ b/test/switch.test.js
@@ -1,0 +1,50 @@
+import React from "react";
+import TestRenderer from "react-test-renderer";
+
+import { Router, Route, Switch } from "../index.js";
+import memoryHistory from "../extra/memory-history";
+
+const testRouteRender = (initialPath, jsx) => {
+  const history = memoryHistory(initialPath);
+  const instance = TestRenderer.create(<Router history={history}>{jsx}</Router>)
+    .root;
+
+  return instance;
+};
+
+it("always renders no more than 1 matched children", () => {
+  const result = testRouteRender(
+    "/users/12",
+    <Switch>
+      <Route path="/users/home">
+        <h1 />
+      </Route>
+      <Route path="/users/:id">
+        <h2 />
+      </Route>
+      <Route path="/users/:rest*">
+        <h3 />
+      </Route>
+    </Switch>
+  );
+
+  const rendered = result.children[0].children;
+
+  expect(rendered.length).toBe(1);
+  expect(result.findByType("h2")).toBeTruthy();
+});
+
+it("ignores mixed children", () => {
+  const result = testRouteRender(
+    "/users",
+    <Switch>
+      Here is a<Route path="/users">route</Route>
+      route
+    </Switch>
+  );
+
+  const rendered = result.children[0].children;
+
+  expect(rendered.length).toBe(1);
+  expect(rendered[0].type).toBe(Route);
+});

--- a/test/switch.test.js
+++ b/test/switch.test.js
@@ -48,3 +48,18 @@ it("ignores mixed children", () => {
   expect(rendered.length).toBe(1);
   expect(rendered[0].type).toBe(Route);
 });
+
+it("allows to specify which routes to render via `location` prop", () => {
+  const result = testRouteRender(
+    "/something-different",
+    <Switch location="/users">
+      <Route path="/users">route</Route>
+    </Switch>
+  );
+
+  const rendered = result.children[0].children;
+
+  expect(rendered.length).toBe(1);
+  expect(rendered[0].type).toBe(Route);
+});
+


### PR DESCRIPTION
Closes #7

  - Adds `Switch` component, similar to React Router's one.
  - `<Switch />` can accept a `location` parameter (handy for doing transitions, see #7)
  - A super simple `Redirect` component