### PR TITLE
Add simple ESLint configuration, fix warnings.

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,6 @@ export const Router = props => {
 };
 
 export const Route = props => {
-  const { children, path } = props;
   const [matches, params] = useRoute(props.path);
 
   if (!matches && !props.match) {
@@ -98,7 +97,9 @@ export const Route = props => {
   }
 
   // support render prop or plain children
-  return typeof children === "function" ? children(params) : children;
+  return typeof props.children === "function"
+    ? props.children(params)
+    : props.children;
 };
 
 export const Link = props => {

--- a/matcher.js
+++ b/matcher.js
@@ -38,7 +38,7 @@ const rxForSegment = (repeat, optional, prefix) => {
 };
 
 const pathToRegexp = (pattern, keys) => {
-  const groupRx = /:([A-Za-z0-9_]+)([\?\+\*]?)/g;
+  const groupRx = /:([A-Za-z0-9_]+)([?+*]?)/g;
 
   let match = null,
     lastIndex = 0,

--- a/package.json
+++ b/package.json
@@ -33,10 +33,26 @@
       "@babel/plugin-transform-react-jsx"
     ]
   },
+  "eslintConfig": {
+    "extends": "eslint:recommended",
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module",
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    },
+    "env": {
+      "browser": true,
+      "node": true,
+      "jest": true
+    }
+  },
   "devDependencies": {
     "@babel/core": "^7.4.3",
     "@babel/plugin-transform-react-jsx": "^7.3.0",
     "@babel/preset-env": "^7.4.3",
+    "eslint": "^5.16.0",
     "jest": "^24.7.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,15 @@
       "browser": true,
       "node": true,
       "jest": true
+    },
+    "rules": {
+      "no-unused-vars": [
+        "error",
+        {
+          "varsIgnorePattern": "^_",
+          "argsIgnorePattern": "^_"
+        }
+      ]
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Adds ESLint for better DX. The configuration is intentionally placed inside `package.json` to keep the number of dotfiles in the project as least as possible. 

The JSX feature doesn't work for some reason, even though the docs say it should. Well, that's minor since we only use JSX in specs and most probably will migrate to something standard (like string to jsx) in the future in order to remove Babel.