### PR TITLE
Fix `Link` component linter warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,24 +103,23 @@ export const Route = props => {
 };
 
 export const Link = props => {
-  const href = props.href || props.to;
-  const child = props.children;
-
   const [, navigate] = useLocation();
-  const onClick = useCallback(
+
+  const href = props.href || props.to;
+  const { children, onClick } = props.children;
+
+  const onClickHandler = useCallback(
     event => {
       event.preventDefault();
       navigate(href);
-      if (props.onClick) {
-        props.onClick();
-      }
+      onClick && onClick();
     },
-    [href, props.onClick]
+    [href, onClick, navigate]
   );
 
   // wraps children in `a` if needed
-  const extraProps = { href, onClick, to: null };
-  const jsx = isValidElement(child) ? child : h("a", props);
+  const extraProps = { href, onClick: onClickHandler, to: null };
+  const jsx = isValidElement(children) ? children : h("a", props);
 
   return cloneElement(jsx, extraProps);
 };

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ export const Link = props => {
   const href = props.href || props.to;
   const { children, onClick } = props.children;
 
-  const onClickHandler = useCallback(
+  const handleClick = useCallback(
     event => {
       event.preventDefault();
       navigate(href);
@@ -118,7 +118,7 @@ export const Link = props => {
   );
 
   // wraps children in `a` if needed
-  const extraProps = { href, onClick: onClickHandler, to: null };
+  const extraProps = { href, onClick: handleClick, to: null };
   const jsx = isValidElement(children) ? children : h("a", props);
 
   return cloneElement(jsx, extraProps);

--- a/package.json
+++ b/package.json
@@ -60,14 +60,20 @@
           "varsIgnorePattern": "^_",
           "argsIgnorePattern": "^_"
         }
-      ]
-    }
+      ],
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn"
+    },
+    "plugins": [
+      "react-hooks"
+    ]
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",
     "@babel/plugin-transform-react-jsx": "^7.3.0",
     "@babel/preset-env": "^7.4.3",
     "eslint": "^5.16.0",
+    "eslint-plugin-react-hooks": "^1.6.0",
     "jest": "^24.7.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",


### PR DESCRIPTION
  - Add lint rules for React Hooks
  - Add missing `navigate` prop to the list of `useCallback` deps (although, not really necessary). Fix the `onClick` warning by rewriting `props.onClick` → `onClick`