### PR TITLE
Get rid of `isValidElement` and `Children`

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ import {
   useContext,
   useCallback,
   createContext,
-  isValidElement,
   cloneElement,
   createElement as h
 } from "react";
@@ -118,7 +117,7 @@ export const Link = props => {
 
   // wraps children in `a` if needed
   const extraProps = { href, onClick: handleClick, to: null };
-  const jsx = isValidElement(children) ? children : h("a", props);
+  const jsx = children && children.props ? children : h("a", props);
 
   return cloneElement(jsx, extraProps);
 };

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -42,6 +42,14 @@ it("works for any other elements as well", () => {
   expect(link.textContent).toBe("Click Me");
 });
 
+it("still creates a plain link when nothing is passed", () => {
+  const { container } = render(<Link href="/about" />);
+  const link = container.firstChild;
+
+  expect(link.tagName).toBe("A");
+  expect(link.getAttribute("href")).toBe("/about");
+});
+
 it("supports `to` prop as an alias to `href`", () => {
   const { container } = render(<Link to="/about">Hello</Link>);
   const link = container.firstChild;

--- a/test/switch.test.js
+++ b/test/switch.test.js
@@ -12,6 +12,11 @@ const testRouteRender = (initialPath, jsx) => {
   return instance;
 };
 
+it("works well when nothing is provided", () => {
+  const result = testRouteRender("/users/12", <Switch />);
+  expect(result.children[0].children.length).toBe(0);
+});
+
 it("always renders no more than 1 matched children", () => {
   const result = testRouteRender(
     "/users/12",
@@ -62,4 +67,3 @@ it("allows to specify which routes to render via `location` prop", () => {
   expect(rendered.length).toBe(1);
   expect(rendered[0].type).toBe(Route);
 });
-


### PR DESCRIPTION
**Why?** because these methods are not provided by Preact and can be replaced with more simplified versions. 

`isValidElement` is replaced with `element && element.props`.
```js
// preact
element && ((element instanceof VNode) || element.$$typeof===REACT_ELEMENT_TYPE)

// react
typeof object === 'object' && object !== null && object.$$typeof === REACT_ELEMENT_TYPE
```

React's `Children` iteration supports things like generators, edge cases like falsey children etc.