### PR TITLE
Consistent implicit routers

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,10 @@ export const useRouter = () => {
   return globalRef.v || (globalRef.v = buildRouter());
 };
 
-export const useLocation = () => useRouter().hook();
+export const useLocation = () => {
+  const router = useRouter();
+  return router.hook(router);
+};
 
 export const useRoute = pattern => {
   const router = useRouter();

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "1.2 KB"
+      "limit": "1.11 KB"
     },
     {
       "path": "use-location.js",
-      "limit": "241 B"
+      "limit": "245 B"
     }
   ],
   "babel": {

--- a/preact/react-deps.js
+++ b/preact/react-deps.js
@@ -2,7 +2,6 @@ export { createContext, cloneElement, createElement } from "preact";
 export { isValidElement } from "preact/compat";
 export {
   useRef,
-  useMemo,
   useEffect,
   useState,
   useContext,

--- a/react-deps.js
+++ b/react-deps.js
@@ -1,6 +1,5 @@
 export {
   useRef,
-  useMemo,
   useEffect,
   useState,
   useContext,

--- a/test/use-router.test.js
+++ b/test/use-router.test.js
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { cloneElement } from "react";
 import { renderHook, act } from "react-hooks-testing-library";
+import TestRenderer from "react-test-renderer";
 
 import { Router, useRouter } from "../index.js";
 
@@ -36,4 +37,25 @@ it("returns customized router provided by the <Router />", () => {
 
   expect(router).toBeInstanceOf(Object);
   expect(router.matcher).toBe(newMatcher);
+});
+
+it("shares one router instance between components", () => {
+  const RouterGetter = ({ el }) => {
+    const router = useRouter();
+    return cloneElement(el, { router: router });
+  };
+
+  const { root, rerender } = TestRenderer.create(
+    <>
+      <RouterGetter el={<div />} />
+      <RouterGetter el={<div />} />
+      <RouterGetter el={<div />} />
+      <RouterGetter el={<div />} />
+    </>
+  );
+
+  const uniqRouters = [
+    ...new Set(root.findAllByType("div").map(x => x.props.router))
+  ];
+  expect(uniqRouters.length).toBe(1);
 });


### PR DESCRIPTION
When a router is created on demand without top-level `Router` component it should always be created once and shared between components. This PR fixes this behaviour.