### PR TITLE
Add `replace` param to `useLocation` updater func

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Make sure you replace the static hook with the real one when you hydrate your ap
 
 We've got some great news for you! If you're a minimalist bundle-size nomad and you need a damn simple
 routing in your app, you can just use the [`useLocation` hook](#uselocation-hook-working-with-the-history)
-which is only **245 bytes gzipped** and manually match the current location with it:
+which is only **247 bytes gzipped** and manually match the current location with it:
 
 ```js
 import useLocation from "wouter/use-location";

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A tiny routing solution for modern React apps that relies on Hooks. A router you wanted so bad in your project!
 
-- Zero dependency, only **1143 B** gzipped vs 17KB [React Router](https://github.com/ReactTraining/react-router).
+- Zero dependency, only **1151 B** gzipped vs 17KB [React Router](https://github.com/ReactTraining/react-router).
 - Supports both **React** and **[Preact](https://preactjs.com/)**! Read _["Preact support" section](#preact-support)_ for more details.
 - No top-level `<Router />` component, it is **fully optional**.
 - Mimics [React Router](https://github.com/ReactTraining/react-router)'s best practices by providing familiar

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "1143 B"
+      "limit": "1151 B"
     },
     {
       "path": "use-location.js",
-      "limit": "245 B"
+      "limit": "247 B"
     }
   ],
   "babel": {

--- a/test/use-location.test.js
+++ b/test/use-location.test.js
@@ -76,4 +76,15 @@ describe("`update` second parameter", () => {
     expect(history.length).toBe(histBefore + 1);
     unmount();
   });
+
+  it("replaces last entry with a new entry in the History object", () => {
+    const { result, unmount } = renderHook(() => useLocation());
+    const update = result.current[1];
+
+    const histBefore = history.length;
+    act(() => update("/about", true));
+
+    expect(history.length).toBe(histBefore);
+    unmount();
+  });
 });

--- a/test/use-location.test.js
+++ b/test/use-location.test.js
@@ -82,9 +82,10 @@ describe("`update` second parameter", () => {
     const update = result.current[1];
 
     const histBefore = history.length;
-    act(() => update("/about", true));
+    act(() => update("/foo", true));
 
     expect(history.length).toBe(histBefore);
+    expect(location.pathname).toBe("/foo");
     unmount();
   });
 });

--- a/use-location.js
+++ b/use-location.js
@@ -13,7 +13,7 @@ export default () => {
     return () => events.map(e => removeEventListener(e, handler));
   }, []);
 
-  return [path, to => history.pushState(0, 0, to)];
+  return [path, (to, replace) => history[replace && "replaceState" || "pushState"](0, 0, to)];
 };
 
 // While History API does have `popstate` event, the only

--- a/use-location.js
+++ b/use-location.js
@@ -13,7 +13,7 @@ export default () => {
     return () => events.map(e => removeEventListener(e, handler));
   }, []);
 
-  return [path, (to, replace) => history[replace && "replaceState" || "pushState"](0, 0, to)];
+  return [path, (to, replace) => history[replace ? "replaceState" : "pushState"](0, 0, to)];
 };
 
 // While History API does have `popstate` event, the only


### PR DESCRIPTION
Add aibility to call replaceState when using `useLocation` hook:

```js
import { useLocation } from 'wouter';

[, setLocation] = useLocation();

setLocation('/about', true); // calls replaceState instead of pushState
```

I also don't know if I need to add a similar prop to Redirect or Link components?