### PR TITLE
Fix children type in Link interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ export const Route: FunctionComponent<RouteProps>;
 export interface LinkProps {
   to?: string;
   href?: string;
-  children: ReactElement;
+  children: ReactNode;
   onClick?: () => void;
 }
 export const Link: FunctionComponent<LinkProps>;


### PR DESCRIPTION
`<Link to="/">Home</Link>`

Link component don't accept text as child element.