### PR TITLE
Add module and types settings in package.json for wouter and wouter/preact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ coverage/
 preact/*
 !preact/react-deps.js
 !preact/index.d.ts
+!preact/package.json

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,11 +1,8 @@
 module.exports = function(api) {
   api.cache(true);
 
-  const presets = ["@babel/preset-env"];
-  const plugins = ["@babel/plugin-transform-react-jsx"];
-
   return {
-    presets,
-    plugins
+    presets: ["@babel/preset-env"],
+    plugins: ["@babel/plugin-transform-react-jsx"],
   };
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = function(api) {
-api.cache(true);
+  api.cache(true);
 
   const presets = ["@babel/preset-env"];
   const plugins = ["@babel/plugin-transform-react-jsx"];

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,11 @@
+module.exports = function(api) {
+api.cache(true);
+
+  const presets = ["@babel/preset-env"];
+  const plugins = ["@babel/plugin-transform-react-jsx"];
+
+  return {
+    presets,
+    plugins
+  };
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "*.d.ts",
     "preact/"
   ],
+  "module": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "jest --verbose --coverage",
     "size": "size-limit",

--- a/package.json
+++ b/package.json
@@ -38,14 +38,6 @@
       "limit": "247 B"
     }
   ],
-  "babel": {
-    "presets": [
-      "@babel/preset-env"
-    ],
-    "plugins": [
-      "@babel/plugin-transform-react-jsx"
-    ]
-  },
   "eslintConfig": {
     "extends": "eslint:recommended",
     "parserOptions": {

--- a/preact/package.json
+++ b/preact/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "wouter-preact",
+  "version": "2.1.1",
+  "private": true,
+  "description": "A minimalistic routing for Preact. Nothing extra, just HOOKS.",
+  "module": "index.js",
+  "types": "index.d.ts",
+  "license": "ISC",
+  "peerDependencies": {
+    "wouter": "^2.1.1",
+    "preact": "^10.0.0-alpha.0"
+  }
+}

--- a/preact/package.json
+++ b/preact/package.json
@@ -8,6 +8,6 @@
   "license": "ISC",
   "peerDependencies": {
     "wouter": "^2.1.1",
-    "preact": "^10.0.0-alpha.0"
+    "preact": "^10.0.0-rc.0"
   }
 }


### PR DESCRIPTION
These settings are useful for tools like [pikapkg](https://www.pika.dev) which require the module settings in order to build wouter. Adding a private `package.json` into the `/preact` folder allow to do `import [..] from "wouter/preact";`

I don't add the `main` setting because most bundlers are waiting for ES5 here, which wouter doesn't provide. And that's ok ;)