### PR TITLE
Types: allow `<Link />` component to accept anchor element attrs

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,6 +3,7 @@
 // * Maksim Karelov <https://github.com/Ty3uK>
 
 import {
+  AnchorHTMLAttributes,
   FunctionComponent,
   ComponentType,
   ReactElement,
@@ -32,11 +33,11 @@ export interface RouteProps {
 }
 export const Route: FunctionComponent<RouteProps>;
 
-export interface LinkProps {
+export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to?: Path;
   href?: Path;
-  children: ReactNode;
   onClick?: () => void;
+  children: ReactNode;
 }
 export const Link: FunctionComponent<LinkProps>;
 

--- a/types/type-specs.tsx
+++ b/types/type-specs.tsx
@@ -65,6 +65,10 @@ const invalidParams: Params = { id: 13 }; // $ExpectError
   <Header />
 </Link>;
 
+// supports standard link attributes
+<Link onClick={() => 0} children={null} />;
+<Link download target="_blank" rel="noreferrer" children={null} />;
+
 <Redirect to="/" />;
 <Redirect href="/" />;
 

--- a/types/type-specs.tsx
+++ b/types/type-specs.tsx
@@ -69,6 +69,17 @@ const invalidParams: Params = { id: 13 }; // $ExpectError
 <Link onClick={() => 0} children={null} />;
 <Link download target="_blank" rel="noreferrer" children={null} />;
 
+<Link
+  children={null}
+  onDrag={event => {
+    event; // $ExpectType DragEvent<HTMLAnchorElement>
+  }}
+/>;
+
+/*
+ * Redirect specs
+ */
+
 <Redirect to="/" />;
 <Redirect href="/" />;
 


### PR DESCRIPTION
Makes it possible to use any prop that a normal link accepts. 