### PR TITLE
Tweak Link component types

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Make sure you replace the static hook with the real one when you hydrate your ap
 
 We've got some great news for you! If you're a minimalist bundle-size nomad and you need a damn simple
 routing in your app, you can just use the [`useLocation` hook](#uselocation-hook-working-with-the-history)
-which is only **247 bytes gzipped** and manually match the current location with it:
+which is only **251 bytes gzipped** and manually match the current location with it:
 
 ```js
 import useLocation from "wouter/use-location";

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ export const Link = props => {
     event => {
       event.preventDefault();
       navigate(href);
-      onClick && onClick();
+      onClick && onClick(event);
     },
     [href, onClick, navigate]
   );

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "use-location.js",
-      "limit": "247 B"
+      "limit": "251 B"
     }
   ],
   "eslintConfig": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -36,8 +36,6 @@ export const Route: FunctionComponent<RouteProps>;
 export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to?: Path;
   href?: Path;
-  onClick?: () => void;
-  children: ReactNode;
 }
 export const Link: FunctionComponent<LinkProps>;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,16 +33,17 @@ export interface RouteProps {
 }
 export const Route: FunctionComponent<RouteProps>;
 
-export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  to?: Path;
-  href?: Path;
-}
+export type NavigationalProps =
+  | { to: Path; href?: never }
+  | { href: Path; to?: never };
+
+export type LinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> &
+  NavigationalProps;
+
 export const Link: FunctionComponent<LinkProps>;
 
-export interface RedirectProps {
-  to?: Path;
-  href?: Path;
-}
+export type RedirectProps = NavigationalProps;
+
 export const Redirect: FunctionComponent<
   RedirectProps & {
     children?: null;

--- a/types/type-specs.tsx
+++ b/types/type-specs.tsx
@@ -8,7 +8,8 @@ import {
   Router,
   useLocation,
   useRoute,
-  PushCallback
+  PushCallback,
+  LinkProps
 } from "wouter";
 
 const Header: React.FunctionComponent = () => <div />;
@@ -51,8 +52,14 @@ const invalidParams: Params = { id: 13 }; // $ExpectError
 /*
  * Link and Redirect component type specs
  */
+
+// `to` and `href` are aliases, but they are mutually exclusive and
+// can't be used at the same time:
 <Link to="/users">Users</Link>;
 <Link href="/about">About</Link>;
+<Link href="/about" to="/app" children="" />; // $ExpectError
+<Link children="" />; // $ExpectError
+
 <Link href="/about">
   This is <i>awesome!</i>
 </Link>;
@@ -67,12 +74,14 @@ const invalidParams: Params = { id: 13 }; // $ExpectError
 
 // supports standard link attributes
 <Link
+  href="/somewhere"
   onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {}}
   children={null}
 />;
-<Link download target="_blank" rel="noreferrer" children={null} />;
+<Link download href="/" target="_blank" rel="noreferrer" children={null} />;
 
 <Link
+  href="/somewhere"
   children={null}
   onDrag={event => {
     event; // $ExpectType DragEvent<HTMLAnchorElement>

--- a/types/type-specs.tsx
+++ b/types/type-specs.tsx
@@ -66,7 +66,10 @@ const invalidParams: Params = { id: 13 }; // $ExpectError
 </Link>;
 
 // supports standard link attributes
-<Link onClick={() => 0} children={null} />;
+<Link
+  onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {}}
+  children={null}
+/>;
 <Link download target="_blank" rel="noreferrer" children={null} />;
 
 <Link


### PR DESCRIPTION
Closes #65
  - `href` and `to` are mutually exclusive
  - `onClick` now accepts an event argument and can be compatible with `onClick` from `AnchorHTMLAttributes`