### PR TITLE
Use effect should only ever return a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,8 +146,8 @@ export const Switch = ({ children, location }) => {
 export const Redirect = props => {
   const [, push] = useLocation();
   useEffect(() => {
-    push(props.href || props.to)
-  });
+    push(props.href || props.to);
+  }, []);
 
   return null;
 };

--- a/index.js
+++ b/index.js
@@ -145,7 +145,9 @@ export const Switch = ({ children, location }) => {
 
 export const Redirect = props => {
   const [, push] = useLocation();
-  useEffect(() => push(props.href || props.to));
+  useEffect(() => {
+    push(props.href || props.to)
+  });
 
   return null;
 };


### PR DESCRIPTION
Currently use effect return the result of `push()` return the length of the array this will cause an warning inside of react.