### PR TITLE
Support a basepath config in <Router/>

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ const RouterCtx = createContext({});
 const buildRouter = (options = {}) => {
   return {
     hook: options.hook || locationHook,
-    matcher: options.matcher || makeMatcher()
+    matcher: options.matcher || makeMatcher(),
+    basepath: options.basepath || ''
   };
 };
 
@@ -43,10 +44,10 @@ export const useLocation = () => {
 };
 
 export const useRoute = pattern => {
-  const router = useRouter();
+  const { matcher, basepath } = useRouter();
   const [path] = useLocation();
 
-  return router.matcher(pattern, path);
+  return matcher(basepath + pattern, path);
 };
 
 /*
@@ -83,9 +84,10 @@ export const Route = ({ path, match, component, children }) => {
 };
 
 export const Link = props => {
+  const { basepath } = useRouter();
   const [, navigate] = useLocation();
 
-  const href = props.href || props.to;
+  const href = basepath + (props.href || props.to);
   const { children, onClick } = props;
 
   const handleClick = useCallback(
@@ -110,6 +112,9 @@ export const Link = props => {
 
   // wraps children in `a` if needed
   const extraProps = { href, onClick: handleClick, to: null };
+
+  // render props
+  if (typeof children === 'function') return children(props);
   const jsx = isValidElement(children) ? children : h("a", props);
 
   return cloneElement(jsx, extraProps);

--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ export const Switch = ({ children, location }) => {
 export const Redirect = props => {
   const [, push] = useLocation();
   useEffect(() => {
-    push(props.href || props.to, false, props.state);
+    push(props.href || props.to, props.replace, props.state);
 
     // we pass an empty array of dependecies to ensure that
     // we only run the effect once after initial render

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 
-import { Link } from "../index.js";
+import { Link, Router } from "../index.js";
 
 afterEach(cleanup);
 
@@ -96,4 +96,28 @@ it("accepts an `onClick` prop, fired after the navigation", () => {
 
   fireEvent.click(getByTestId("link"));
   expect(clickHandler).toHaveBeenCalledTimes(1);
+});
+
+it("performs a navigation with basepath when the link is clicked", () => {
+  const { getByTestId } = render(
+    <Router basepath="/app">
+      <Link href="/about" data-testid="link"/>
+    </Router>
+  );
+
+  fireEvent.click(getByTestId("link"));
+  expect(location.pathname).toBe("/app/about");
+});
+
+it("performs a custom navigation component with basepath when the link is clicked", () => {
+  const { getByTestId } = render(
+    <Router basepath="/app">
+      <Link href="/about" data-testid="link">
+        { props => <a data-testid="link" href={props.href}/>}
+      </Link>
+    </Router>
+  );
+
+  fireEvent.click(getByTestId("link"));
+  expect(location.pathname).toBe("/app/about");
 });

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -112,8 +112,21 @@ it("performs a navigation with basepath when the link is clicked", () => {
 it("performs a custom navigation component with basepath when the link is clicked", () => {
   const { getByTestId } = render(
     <Router basepath="/app">
-      <Link href="/about" data-testid="link">
-        { props => <a data-testid="link" href={props.href}/>}
+      <Link href="/about" data-testid="link"/>
+    </Router>
+  );
+
+  fireEvent.click(getByTestId("link"));
+  expect(location.pathname).toBe("/app/about");
+});
+
+it("link can support render props", () => {
+  const { getByTestId } = render(
+    <Router basepath="/app">
+      <Link>
+        {
+          ({navigate}) => <a data-testid="link" onClick={() => navigate('/about')}>click to navigate</a>
+        }
       </Link>
     </Router>
   );

--- a/test/preact.test.js
+++ b/test/preact.test.js
@@ -33,16 +33,18 @@ describe("Preact support", () => {
           </Link>
         </nav>
 
-        <main data-testid="routes">
-          <Switch>
-            Welcome to the list of {100} greatest albums of all time!
-            <Route path="/albums/all">Rolling Stones Best 100 Albums</Route>
-            <Route path="/albums/:name">
-              {params => `Album ${params.name}`}
-            </Route>
-            <Route path="/:anything*">Nothing was found!</Route>
-          </Switch>
-        </main>
+        <Router basepath="/app">
+          <main data-testid="routes">
+            <Switch>
+              Welcome to the list of {100} greatest albums of all time!
+              <Route path="/albums/all">Rolling Stones Best 100 Albums</Route>
+              <Route path="/albums/:name">
+                {params => `Album ${params.name}`}
+              </Route>
+              <Route default>Nothing was found!</Route>
+            </Switch>
+          </main>
+        </Router>
       </Fragment>
     );
 

--- a/test/redirect.test.js
+++ b/test/redirect.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import { Redirect } from "../index.js";
+import { Redirect, Router } from "../index.js";
 
 it("renders nothing", () => {
   const { container, unmount } = render(<Redirect to="/users" />);
@@ -14,4 +14,14 @@ it("results in change of current location", () => {
 
   expect(location.pathname).toBe("/users");
   unmount();
+});
+
+it("redirect with a basepath router", () => {
+  render(
+    <Router basepath="/app">
+      <Redirect to='/users'/>
+    </Router>
+  );
+
+  expect(location.pathname).toBe("/app/users");
 });

--- a/test/route-rendering.test.js
+++ b/test/route-rendering.test.js
@@ -67,8 +67,8 @@ it("renders via a basepath", () => {
   const Users = () => <h2>All users</h2>;
 
   const result = testRouteRender(
-    "/app/foo",
-    <Route path="/foo" component={Users} />,
+    "/app/users",
+    <Route path="/users" component={Users} />,
     '/app'
   );
 

--- a/test/route-rendering.test.js
+++ b/test/route-rendering.test.js
@@ -4,9 +4,9 @@ import TestRenderer from "react-test-renderer";
 import { Router, Route } from "../index.js";
 import { memoryLocation } from "./test-utils.js";
 
-const testRouteRender = (initialPath, jsx) => {
+const testRouteRender = (initialPath, jsx, basepath = '') => {
   const instance = TestRenderer.create(
-    <Router hook={memoryLocation(initialPath)}>{jsx}</Router>
+    <Router hook={memoryLocation(initialPath)} basepath={basepath}>{jsx}</Router>
   ).root;
 
   return instance;
@@ -58,6 +58,18 @@ it("supports `component` prop similar to React-Router", () => {
   const result = testRouteRender(
     "/foo",
     <Route path="/foo" component={Users} />
+  );
+
+  expect(result.findByType("h2").props.children).toBe("All users");
+});
+
+it("renders via a basepath", () => {
+  const Users = () => <h2>All users</h2>;
+
+  const result = testRouteRender(
+    "/app/foo",
+    <Route path="/foo" component={Users} />,
+    '/app'
   );
 
   expect(result.findByType("h2").props.children).toBe("All users");

--- a/test/switch.test.js
+++ b/test/switch.test.js
@@ -9,9 +9,9 @@ import { render, act } from "@testing-library/react";
 const raf = () =>
   new Promise((resolve, reject) => requestAnimationFrame(resolve));
 
-const testRouteRender = (initialPath, jsx) => {
+const testRouteRender = (initialPath, jsx, basepath = '') => {
   const instance = TestRenderer.create(
-    <Router hook={memoryLocation(initialPath)}>{jsx}</Router>
+    <Router hook={memoryLocation(initialPath)} basepath={basepath}>{jsx}</Router>
   ).root;
 
   return instance;
@@ -112,4 +112,53 @@ it("always ensures the consistency of inner routes rendering", async () => {
   });
 
   unmount();
+});
+
+it("renders one match child route via basepath and without location props", () => {
+  const result = testRouteRender(
+    "/app/users",
+    <Switch>
+      <Route path="/users"><h1 /></Route>
+      <Route path="/others"><h2 /></Route>
+    </Switch>,
+    '/app'
+  );
+
+  const rendered = result.children[0].children;
+
+  expect(rendered.length).toBe(1);
+  expect(result.findByType("h1")).toBeTruthy();
+});
+
+it("render one match child route where both basepath and location exist", () => {
+  const result = testRouteRender(
+    "/app/users",
+    <Switch location="/others">
+      <Route path="/users"><h1 /></Route>
+      <Route path="/others"><h2 /></Route>
+    </Switch>,
+    '/app'
+  );
+
+  const rendered = result.children[0].children;
+
+  expect(rendered.length).toBe(1);
+  expect(result.findByType("h2")).toBeTruthy();
+});
+
+it("render default route when no route's path be matched", () => {
+  const result = testRouteRender(
+    "/app/users",
+    <Switch>
+      <Route path="/anything-one"><h1 /></Route>
+      <Route default><h2 /></Route>
+      <Route path="/anything-two"><h3 /></Route>
+    </Switch>,
+    '/app'
+  );
+
+  const rendered = result.children[0].children;
+
+  expect(rendered.length).toBe(1);
+  expect(result.findByType("h2")).toBeTruthy();
 });

--- a/use-location.js
+++ b/use-location.js
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from "./react-deps.js";
 
-export default () => {
+export default ({ basepath = '', ...others } = {}) => {
   const [path, update] = useState(location.pathname);
 
   useEffect(() => {
@@ -19,7 +19,7 @@ export default () => {
   // the function reference should stay the same between re-renders, so that
   // it can be passed down as an element prop without any performance concerns.
   const navigate = useCallback(
-    (to, replace) => history[replace ? "replaceState" : "pushState"](0, 0, to),
+    (to, replace, state) => history[replace ? "replaceState" : "pushState"](state, 0, basepath + to),
     []
   );
 


### PR DESCRIPTION
I really like this library, I want to get involved and make this library a bit cooler.
I noticed a discussion about `basepath`, my plan is like this:

```javascript
<Router basepath='/app'>
  <Route path='/about' />
</Router>

// Link also have this ability
<Link href='/about' />

// also
<Link href='/about'>
 { props => <span><a href={props.href}>click here</></span>}
</Link>
```
then, when the link be clicked, will navigate to the url `/app/about`。
so, It will be no burden for the user.

Of course, I can make it more detailed, but I think it is enough now.

Looking forward to your review!