### PR TITLE
Ship CommonJS sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ preact/*
 # type definitions in the project root are copied from types/ folder
 # before publishing, so they should be ignored
 /*.d.ts
+
+# ignore bundled CommonJS files
+cjs/

--- a/README.md
+++ b/README.md
@@ -36,11 +36,9 @@ const App = () => (
 );
 ```
 
-### This library comes untranspiled, please read this!
+### Supporting IE11 and obsolete platforms
 
-**TL;DR** Want to support IE11 → make sure you transpile `node_modules`.
-
-The library is written in pure ES6 and doesn't come with transpiled sources. There is a [big debate going on](https://gist.github.com/Rich-Harris/51e1bf24e7c093469ef7a0983bad94cb) it the community on whether or not libraries should ship untranspiled code. Wouter was designed to be as small as possible and the decision to ship raw ES6 was made intentionally. We only use basic things like arrow functions and destructive assignment, so it should work fine in the [majority of the browsers](https://caniuse.com/#feat=es6). If you'd like to aim platforms like IE11, please make sure you run Babel over your `node_modules`.
+This library uses features like [destructuring assignment](https://kangax.github.io/compat-table/es6/#test-destructuring,_assignment) and [`const/let` declarations](https://kangax.github.io/compat-table/es6/#test-const) and doesn't ship with ES5 transpiled sources. If you aim to support browsers like IE11 and below → make sure you run Babel over your `node_modules`
 
 ## Wouter API
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "cjs"
   ],
   "module": "index.js",
+  "main": "cjs/index.js",
   "types": "index.d.ts",
   "scripts": {
     "test": "jest --verbose --coverage",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "files": [
     "*.js",
     "*.d.ts",
-    "preact"
+    "preact",
+    "cjs"
   ],
   "module": "index.js",
   "types": "index.d.ts",
@@ -24,7 +25,8 @@
     "lint-types": "dtslint types --onlyTestTsNext && dtslint types/preact --onlyTestTsNext",
     "pack-react": "copyfiles -f types/*.d.ts .",
     "pack-preact": "copyfiles -f {index,matcher,use-location,static-location}.js types/{matcher,use-location,static-location}.d.ts types/preact/index.d.ts preact/",
-    "prepublishOnly": "npm run pack-react && npm run pack-preact"
+    "bundle-cjs": "rollup -e react,preact,preact/hooks,preact/compat -f cjs --exports named --preserveModules -d cjs *.js preact/*.js",
+    "prepublishOnly": "npm run pack-react && npm run pack-preact && npm run bundle-cjs"
   },
   "author": "Alexey Taktarov <molefrog@gmail.com>",
   "license": "ISC",
@@ -86,11 +88,12 @@
     "eslint": "^6.2.1",
     "eslint-plugin-react-hooks": "^1.7.0",
     "jest": "^24.9.0",
+    "jest-esm-jsx-transform": "^1.0.0",
     "preact": "^10.0.0-rc.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-test-renderer": "^16.9.0",
-    "size-limit": "^2.1.1",
-    "jest-esm-jsx-transform": "^1.0.0"
+    "rollup": "^1.19.4",
+    "size-limit": "^2.1.1"
   }
 }


### PR DESCRIPTION
Rollup runs on prepublish and outputs CJS sources into `cjs/` folder. See #70 