### PR TITLE
Delay redirecting until "history" was hooked in Switch

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import makeMatcher from "./matcher.js";
 
 import {
   useRef,
+  useState,
   useEffect,
   useContext,
   useCallback,
@@ -140,13 +141,18 @@ export const Switch = ({ children, location }) => {
 };
 
 export const Redirect = props => {
+  const [delayed, update] = useState(false);
   const [, push] = useLocation();
   useEffect(() => {
-    push(props.href || props.to);
+    if (delayed) {
+      push(props.href || props.to);
+    } else {
+      update(true);
+    }
 
-    // we pass an empty array of dependecies to ensure that
+    // we pass only `delayed` as dependecies to ensure that
     // we only run the effect once after initial render
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [delayed]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return null;
 };


### PR DESCRIPTION
"Switch" cannot detect redirect immediately after mounting.
Sample code: https://codesandbox.io/s/flamboyant-merkle-zqm4c?fontsize=14

```jsx
<Switch>
    <Route path="/hello">Hello Wouter!</Route>
    <Route path="/:rest*">
      If you see this, Wouter cannot detect the redirect.
      <Redirect to="/hello" />
    </Route>
</Switch>
```

The function called from "useEffect" is called first from the function of the child element.
Because of that, "Switch" cannot hooks history before calling `useEffect` in "Redirect" for redirecting.

This PR fixes that issue.
The solution is, "Redirect" calls `useEffect` twice to delay redirecting.
At first `useEffect` calling, "Redirect" does nothing, but "Switch" hooks history.
At 2nd `useEffect` calling, "Redirect" redirects, and emit event.
"Switch" already hooks history, so "Switch" can detect redirect immediately after mounting.