### PR TITLE
TS types: add generic for Params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 npm-debug.log*
 node_modules/
 .npm
+yarn.lock
 
 # ignore package-lock.json since it's a package
 # see https://github.com/sindresorhus/ama/issues/479#issuecomment-310661514

--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,11 @@
 npm-debug.log*
 node_modules/
 .npm
-yarn.lock
 
 # ignore package-lock.json since it's a package
 # see https://github.com/sindresorhus/ama/issues/479#issuecomment-310661514
 /package-lock.json
+/yarn.lock
 
 # bundler
 dist/

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,22 +16,24 @@ export type PushCallback = (to: Path, replace?: boolean) => void;
 export type LocationTuple = [Path, PushCallback];
 export type LocationHook = () => LocationTuple;
 
-export interface Params {
+export interface DefaultParams {
   [paramName: string]: string;
 }
+export type Params<T extends DefaultParams = DefaultParams> = T;
 
-export type MatchWithParams = [true, Params];
+export type MatchWithParams<T extends DefaultParams = DefaultParams> = [true, Params<T>];
 export type NoMatch = [false, null];
-export type Match = MatchWithParams | NoMatch;
+export type Match<T extends DefaultParams = DefaultParams> = MatchWithParams<T> | NoMatch;
 
 export type MatcherFn = (pattern: Path, path: Path) => Match;
 
-export interface RouteProps {
-  children?: ((params: Params) => ReactNode) | ReactNode;
+export interface RouteProps<T extends DefaultParams = DefaultParams> {
+  children?: ((params: Params<T>) => ReactNode) | ReactNode;
   path: Path;
   component?: ComponentType<any>;
 }
-export const Route: FunctionComponent<RouteProps>;
+
+export function Route<T extends DefaultParams = DefaultParams>(props: RouteProps<T>): ReactElement | null;  // tslint:disable-line:no-unnecessary-generics
 
 export type NavigationalProps =
   | { to: Path; href?: never }
@@ -66,6 +68,6 @@ export const Router: FunctionComponent<
 
 export function useRouter(): RouterProps;
 
-export function useRoute(pattern: Path): Match;
+export function useRoute<T extends DefaultParams = DefaultParams>(pattern: Path): Match<T>; // tslint:disable-line:no-unnecessary-generics
 
 export function useLocation(): LocationTuple;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,6 +21,10 @@ export interface DefaultParams {
 }
 export type Params<T extends DefaultParams = DefaultParams> = T;
 
+export interface RouteComponentProps<T extends DefaultParams = DefaultParams> {
+  params: T;
+}
+
 export type MatchWithParams<T extends DefaultParams = DefaultParams> = [true, Params<T>];
 export type NoMatch = [false, null];
 export type Match<T extends DefaultParams = DefaultParams> = MatchWithParams<T> | NoMatch;
@@ -30,7 +34,7 @@ export type MatcherFn = (pattern: Path, path: Path) => Match;
 export interface RouteProps<T extends DefaultParams = DefaultParams> {
   children?: ((params: Params<T>) => ReactNode) | ReactNode;
   path: Path;
-  component?: ComponentType<any>;
+  component?: ComponentType<RouteComponentProps<T>>;
 }
 
 export function Route<T extends DefaultParams = DefaultParams>(props: RouteProps<T>): ReactElement | null;  // tslint:disable-line:no-unnecessary-generics

--- a/types/preact/index.d.ts
+++ b/types/preact/index.d.ts
@@ -16,22 +16,27 @@ export type PushCallback = (to: Path, replace?: boolean) => void;
 export type LocationTuple = [Path, PushCallback];
 export type LocationHook = () => LocationTuple;
 
-export interface Params {
+export interface DefaultParams {
   [paramName: string]: string;
 }
+export type Params<T extends DefaultParams = DefaultParams> = T;
 
-export type MatchWithParams = [true, Params];
+export interface RouteComponentProps<T extends DefaultParams = DefaultParams> {
+  params: T;
+}
+
+export type MatchWithParams<T extends DefaultParams = DefaultParams> = [true, Params<T>];
 export type NoMatch = [false, null];
-export type Match = MatchWithParams | NoMatch;
+export type Match<T extends DefaultParams = DefaultParams> = MatchWithParams<T> | NoMatch;
 
 export type MatcherFn = (pattern: Path, path: Path) => Match;
 
-export interface RouteProps {
-  children?: ((params: Params) => ComponentChildren) | ComponentChildren;
+export interface RouteProps<T extends DefaultParams = DefaultParams> {
+  children?: ((params: Params<T>) => ComponentChildren) | ComponentChildren;
   path: Path;
-  component?: ComponentType<any>;
+  component?: ComponentType<RouteComponentProps<T>>;
 }
-export const Route: FunctionComponent<RouteProps>;
+export function Route<T extends DefaultParams = DefaultParams>(props: RouteProps<T>): VNode<any> | null; // tslint:disable-line:no-unnecessary-generics
 
 export type NavigationalProps =
   | { to: Path; href?: never }
@@ -62,6 +67,6 @@ export const Router: FunctionComponent<
 
 export function useRouter(): RouterProps;
 
-export function useRoute(pattern: Path): Match;
+export function useRoute<T extends DefaultParams = DefaultParams>(pattern: Path): Match<T>; // tslint:disable-line:no-unnecessary-generics
 
 export function useLocation(): LocationTuple;

--- a/types/preact/type-specs.tsx
+++ b/types/preact/type-specs.tsx
@@ -1,25 +1,33 @@
-import { h, FunctionComponent } from "preact";
+import { FunctionComponent, h } from "preact";
 import {
-  Route,
-  Params,
   Link,
+  Params,
   Redirect,
-  Switch,
+  Route,
+  RouteComponentProps,
   Router,
+  Switch,
   useLocation,
   useRoute,
-  PushCallback
 } from "wouter/preact";
 
 const Header: FunctionComponent = () => <div />;
+const Profile = ({ params }: RouteComponentProps<{ id: string }>) => (
+    <div>User id: {params.id}</div>
+);
 
 /*
  * Params type specs
  */
 const someParams: Params = { foo: "bar" };
+const someParamsWithGeneric: Params<{ foo: string }> = { foo: "bar" };
+
+// error: params should follow generic type
+const paramsDontMatchGeneric: Params<{ foo: string }> = { baz: "bar" };  // $ExpectError
 
 // error: values are strings!
 const invalidParams: Params = { id: 13 }; // $ExpectError
+const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectError
 
 /*
  * <Route /> component type specs
@@ -33,6 +41,9 @@ const invalidParams: Params = { id: 13 }; // $ExpectError
 
 // Supports various ways to declare children
 <Route path="/header" component={Header} />;
+<Route path="/profile/:id" component={Profile} />;
+<Route<{ id: string }> path="/profile/:id" component={Profile} />;
+<Route<{ name: string }> path="/profile/:name" component={Profile} />; // $ExpectError
 
 <Route path="/app">
   <div />
@@ -44,6 +55,14 @@ const invalidParams: Params = { id: 13 }; // $ExpectError
 
 <Route path="/users/:id">
   {(params: Params): React.ReactNode => `User id: ${params.id}`}
+</Route>;
+
+<Route<{ id: string }> path="/users/:id">
+  {({ id }) => `User id: ${id}`}
+</Route>;
+
+<Route<{ id: string }> path="/users/:id">
+  {({ age }) => `User age: ${age}`} // $ExpectError
 </Route>;
 
 <Route path="/app" match={true} />; // $ExpectError
@@ -119,11 +138,12 @@ useRoute(Symbol()); // $ExpectError
 useRoute(); // $ExpectError
 useRoute("/");
 
-const [match, params] = useRoute("/app/users/:id");
+const [match, params] = useRoute<{ id: string }>("/app/users/:id");
 match; // $ExpectType boolean
 
 if (params) {
   params.id; // $ExpectType string
+  params.age; // $ExpectError
 } else {
   params; // $ExpectType null
 }

--- a/types/type-specs.tsx
+++ b/types/type-specs.tsx
@@ -1,18 +1,20 @@
 import * as React from "react";
 import {
-  Route,
-  Params,
   Link,
+  Params,
   Redirect,
-  Switch,
+  Route,
+  RouteComponentProps,
   Router,
+  Switch,
   useLocation,
   useRoute,
-  PushCallback,
-  LinkProps
 } from "wouter";
 
 const Header: React.FunctionComponent = () => <div />;
+const Profile = ({ params }: RouteComponentProps<{ id: string }>) => (
+  <div>User id: {params.id}</div>
+);
 
 /*
  * Params type specs
@@ -39,6 +41,9 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
 
 // Supports various ways to declare children
 <Route path="/header" component={Header} />;
+<Route path="/profile/:id" component={Profile} />;
+<Route<{ id: string }> path="/profile/:id" component={Profile} />;
+<Route<{ name: string }> path="/profile/:name" component={Profile} />; // $ExpectError
 
 <Route path="/app">
   <div />

--- a/types/type-specs.tsx
+++ b/types/type-specs.tsx
@@ -18,9 +18,14 @@ const Header: React.FunctionComponent = () => <div />;
  * Params type specs
  */
 const someParams: Params = { foo: "bar" };
+const someParamsWithGeneric: Params<{ foo: string }> = { foo: "bar" };
+
+// error: params should follow generic type
+const paramsDontMatchGeneric: Params<{ foo: string }> = { baz: "bar" };  // $ExpectError
 
 // error: values are strings!
 const invalidParams: Params = { id: 13 }; // $ExpectError
+const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectError
 
 /*
  * <Route /> component type specs
@@ -45,6 +50,14 @@ const invalidParams: Params = { id: 13 }; // $ExpectError
 
 <Route path="/users/:id">
   {(params: Params): React.ReactNode => `User id: ${params.id}`}
+</Route>;
+
+<Route<{ id: string }> path="/users/:id">
+  {({ id }) => `User id: ${id}`}
+</Route>;
+
+<Route<{ id: string }> path="/users/:id">
+  {({ age }) => `User age: ${age}`} // $ExpectError
 </Route>;
 
 <Route path="/app" match={true} />; // $ExpectError
@@ -135,11 +148,12 @@ useRoute(Symbol()); // $ExpectError
 useRoute(); // $ExpectError
 useRoute("/");
 
-const [match, params] = useRoute("/app/users/:id");
+const [match, params] = useRoute<{ id: string }>("/app/users/:id");
 match; // $ExpectType boolean
 
 if (params) {
   params.id; // $ExpectType string
+  params.age; // $ExpectError
 } else {
   params; // $ExpectType null
 }


### PR DESCRIPTION
Thanks for this lib and bundling the types !

React hooks types use a lot generics and I would like to get the same with wouter.

Sadly I ran into the [no-unnecessary-generics](https://github.com/Microsoft/dtslint/blob/master/docs/no-unnecessary-generics.md) of dtslint. The doc suggest that I should use the `as` keyword but even [@types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L949) provide generics. There is a [stale issue](https://github.com/microsoft/dtslint/issues/76) about this. 

If you agree I will make the same changes for preact types

Note: I added yarn.lock for convenience, but I can remove it.