### PR TITLE
Allow passing replace & state props

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,15 @@ a navigation with it, this is very similar to how you work with values returned 
 import { useLocation } from "wouter";
 
 const CurrentLocation = () => {
-  const [location, setLocation] = useLocation();
+  const [location, setLocation, state] = useLocation();
 
   return (
     <div>
       {`The current page is: ${location}`}
+      {`The current page location state is: ${state}`}
       <a onClick={() => setLocation("/somewhere")}>Click to update</a>
+      <a onClick={() => setLocation("/somewhere", true)}>Click to update replacing the last entry in the browsing history</a>
+      <a onClick={() => setLocation("/somewhere", false, { from: '/here' })}>Click to update with an additional location state object</a>
     </div>
   );
 };
@@ -193,7 +196,7 @@ import { Route } from "wouter";
 <Route path="/orders/:status" component={Orders} />
 ```
 
-### `<Link href={path} />`
+### `<Link href={path} replace state={stateObj} />`
 
 Link component renders an `<a />` element that, when clicked, performs a navigation. You can customize the link appearance
 by providing your own component or link element as `children`:
@@ -211,7 +214,16 @@ import { Link } from "wouter";
 // will be passed down to an element
 <Link href="/foo"><a className="active">Hello!</a></Link>
 <Link href="/foo"><A>Hello!</A></Link>
+
+// when using `replace` the last entry in the browsing history will be replaced
+// by `/foo` location
+<Link href="/foo" replace className="active">Hello!</Link>
+// when using `state` a location state object will be set and made accesible
+// using the third argument of the `useLocation` return value
+<Link href="/foo" state={{ exampleState: true }} className="active">Hello!</Link>
 ```
+
+`replace` and `state` props are optional.
 
 ### `<Switch />`
 
@@ -229,9 +241,10 @@ import { Route, Switch } from "wouter";
 
 Check out [**FAQ and Code Recipes** section](#faq-and-code-recipes) for more advanced use of `Switch`.
 
-### `<Redirect to={path} />`
+### `<Redirect to={path} replace state={stateObj} />`
 
 When mounted performs a redirect to a `path` provided. Uses `useLocation` hook internally to trigger the navigation inside of a `useEffect` block.
+`replace` and `state` props are optional.
 
 If you need more advanced logic for navigation, for example, to trigger
 the redirect inside of an event handler, consider using [`useLocation` hook instead](#uselocation-hook-working-with-the-history):

--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ Preact exports are available through a separate package named `wouter-preact` (o
 
 You might need to ensure you have the latest version of [Preact X](https://github.com/preactjs/preact/releases/tag/10.0.0-alpha.0) with support for hooks.
 
+**[▶ Demo Sandbox](https://codesandbox.io/s/wouter-preact-0lr3n)**
+
 ### Is there any support for server-side rendering (SSR)?
 
 Yes! In order to render your app on a server, you'll need to tell the router that the current location comes from the request rather than the browser history. In **wouter**, you can achieve that by replacing the default `useLocation` hook with a static one:

--- a/index.js
+++ b/index.js
@@ -82,11 +82,11 @@ export const Route = ({ path, match, component, children }) => {
   return typeof children === "function" ? children(params) : children;
 };
 
-export const Link = props => {
+export const Link = ({ replace, ...props }) => {
   const [, navigate] = useLocation();
 
   const href = props.href || props.to;
-  const { children, onClick } = props;
+  const { children, onClick, state } = props;
 
   const handleClick = useCallback(
     event => {
@@ -102,10 +102,10 @@ export const Link = props => {
         return;
 
       event.preventDefault();
-      navigate(href);
+      navigate(href, replace, state);
       onClick && onClick(event);
     },
-    [href, onClick, navigate]
+    [href, replace, state, onClick, navigate]
   );
 
   // wraps children in `a` if needed
@@ -119,7 +119,9 @@ export const Switch = ({ children, location }) => {
   const { matcher } = useRouter();
   const [originalLocation] = useLocation();
 
-  children = Array.isArray(children) ? children : [children];
+  if (!Array.isArray(children)) {
+    children = [children];
+  }
 
   for (const element of children) {
     let match = 0;
@@ -142,9 +144,9 @@ export const Switch = ({ children, location }) => {
 export const Redirect = props => {
   const [, push] = useLocation();
   useLayoutEffect(() => {
-    push(props.href || props.to);
+    push(props.href || props.to, props.replace, props.state);
 
-    // we pass an empty array of dependecies to ensure that
+    // we pass an empty array of dependencies to ensure that
     // we only run the effect once after initial render
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -58,7 +58,7 @@ it("supports `to` prop as an alias to `href`", () => {
 });
 
 it("performs a navigation when the link is clicked", () => {
-  const { container, getByTestId } = render(
+  const { getByTestId } = render(
     <Link href="/goo-baz">
       <a data-testid="link" />
     </Link>
@@ -68,7 +68,7 @@ it("performs a navigation when the link is clicked", () => {
 });
 
 it("ignores the navigation when clicked with modifiers", () => {
-  const { container, getByTestId } = render(
+  const { getByTestId } = render(
     <Link href="/users" data-testid="link">
       click
     </Link>
@@ -88,7 +88,7 @@ it("ignores the navigation when clicked with modifiers", () => {
 it("accepts an `onClick` prop, fired after the navigation", () => {
   const clickHandler = jest.fn();
 
-  const { container, getByTestId } = render(
+  const { getByTestId } = render(
     <Link href="/" onClick={clickHandler}>
       <a data-testid="link" />
     </Link>
@@ -96,4 +96,30 @@ it("accepts an `onClick` prop, fired after the navigation", () => {
 
   fireEvent.click(getByTestId("link"));
   expect(clickHandler).toHaveBeenCalledTimes(1);
+});
+
+it("accepts a `replace` prop to replace last history entry instead of add a new one after navigation", () => {
+  const { getByTestId } = render(
+    <Link href="/replacing" replace>
+      <a data-testid="link" />
+    </Link>
+  );
+
+  const prevHistoryLength = history.length;
+  fireEvent.click(getByTestId("link"));
+  expect(location.pathname).toBe("/replacing");
+  expect(history.length).toEqual(prevHistoryLength);
+});
+
+it("accepts a `state` prop to pass some state along with navigation", () => {
+  const state = { from: "/" };
+  const { getByTestId } = render(
+    <Link href="/with-state" state={state}>
+      <a data-testid="link" />
+    </Link>
+  );
+
+  fireEvent.click(getByTestId("link"));
+  expect(location.pathname).toBe("/with-state");
+  expect(history.state).toMatchObject(state);
 });

--- a/test/redirect.test.js
+++ b/test/redirect.test.js
@@ -1,7 +1,7 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 
-import { Redirect } from "../index.js";
+import { Link, Redirect } from "../index.js";
 
 it("renders nothing", () => {
   const { container, unmount } = render(<Redirect to="/users" />);
@@ -10,8 +10,41 @@ it("renders nothing", () => {
 });
 
 it("results in change of current location", () => {
+  const prevHistoryLength = history.length;
   const { unmount } = render(<Redirect to="/users" />);
 
   expect(location.pathname).toBe("/users");
+  expect(history.length).toBe(prevHistoryLength + 1);
+  unmount();
+});
+
+it("accepts a `replace` prop to replace last history entry instead of add a new one after redirection", () => {
+  const { getByTestId } = render(
+    <Link href="/admin">
+      <a data-testid="link" />
+    </Link>
+  );
+
+  fireEvent.click(getByTestId("link"));
+  expect(location.pathname).toBe("/admin");
+  const prevHistoryLength = history.length;
+  const { unmount } = render(<Redirect replace to="/users" />);
+  expect(history.length).toEqual(prevHistoryLength);
+  unmount();
+});
+
+it("accepts a `state` prop to pass some state along with redirection", () => {
+  const state = { from: "/admin" };
+  const { getByTestId } = render(
+    <Link href="/admin">
+      <a data-testid="link" />
+    </Link>
+  );
+
+  fireEvent.click(getByTestId("link"));
+  expect(location.pathname).toBe("/admin");
+  expect(history.state).toBe(0);
+  const { unmount } = render(<Redirect state={state} to="/users" />);
+  expect(history.state).toMatchObject(state);
   unmount();
 });


### PR DESCRIPTION
Closes #75

Allow passing `replace` & `state` props to `Link`, `Redirect` and `useLocation`.

`useLocation` already has the possibility to pass `replace`, but that wasn't being used by `Link` and `Redirect` (which should be allowed, as far as I remember, most of the routing libraries with that feature are doing it). I had to add it because that (consistency), plus anyways I needed to pass the third value for the `state`.

Didn't create an extra accessor for the history `state` because I felt it kinda logic this way. I mean, when we add a `state`, we want it to use in the location we're moving to at that moment, so it sounds logic to me to add it there.
I edited it considering to not make any breaking change and that prior code worked without changes. I hope I didn't miss anything.

Also updated the `README.md` with the changes and the tests accordingly. 

I have been monitoring #75 a few months now, waiting for some action or maybe to @destructobeam to make a PR, and like I see no movement, I just make a try. If you feel this wrong o whatever just discard this and have my apologies :).

In any case, I wanted to use `wouter` this summer to migrate a tiny silly project of mine (used just for experimenting), but like this feature (`state`) wasn't supported, I had to discard it. For me, this is a key feature and IDK, most route libraries support it because native `history` also support it, so.

I tried to do the fewer changes possible, but anyways `yarn run size` fails, because it looks like... the size limit is just adjusted to the current size, right? So, if this looks good (or after some revisions, it ends looking that way), that limit should be upped in `package.json` and `README.md`.