### PR TITLE
Basic basepath support

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,13 +22,11 @@ import {
 // the implicitly created router (see `useRouter` below)
 const RouterCtx = createContext({});
 
-const buildRouter = (options = {}) => {
-  return {
-    hook: options.hook || locationHook,
-    basepath: options.basepath || "",
-    matcher: options.matcher || makeMatcher()
-  };
-};
+const buildRouter = ({
+  hook = locationHook,
+  basepath = "",
+  matcher = makeMatcher()
+} = {}) => ({ hook, basepath, matcher });
 
 export const useRouter = () => {
   const globalRef = useContext(RouterCtx);

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const RouterCtx = createContext({});
 const buildRouter = (options = {}) => {
   return {
     hook: options.hook || locationHook,
+    basepath: options.basepath || "",
     matcher: options.matcher || makeMatcher()
   };
 };
@@ -84,6 +85,7 @@ export const Route = ({ path, match, component, children }) => {
 
 export const Link = props => {
   const [, navigate] = useLocation();
+  const { basepath } = useRouter();
 
   const href = props.href || props.to;
   const { children, onClick } = props;
@@ -109,7 +111,7 @@ export const Link = props => {
   );
 
   // wraps children in `a` if needed
-  const extraProps = { href, onClick: handleClick, to: null };
+  const extraProps = { href: basepath + href, onClick: handleClick, to: null };
   const jsx = isValidElement(children) ? children : h("a", props);
 
   return cloneElement(jsx, extraProps);

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 
-import { Link } from "../index.js";
+import { Router, Link } from "../index.js";
 
 afterEach(cleanup);
 
@@ -96,4 +96,15 @@ it("accepts an `onClick` prop, fired after the navigation", () => {
 
   fireEvent.click(getByTestId("link"));
   expect(clickHandler).toHaveBeenCalledTimes(1);
+});
+
+it("renders `href` with basepath", () => {
+  const { getByTestId } = render(
+    <Router basepath="/app">
+      <Link href="/dashboard" data-testid="link" />
+    </Router>
+  );
+
+  const link = getByTestId("link");
+  expect(link.getAttribute("href")).toBe("/app/dashboard");
 });

--- a/test/use-location.test.js
+++ b/test/use-location.test.js
@@ -45,6 +45,16 @@ describe("`value` first argument", () => {
     expect(result.current[0]).toBe("/");
     unmount();
   });
+
+  it("returns a pathname without a basepath", () => {
+    const { result, unmount } = renderHook(() =>
+      useLocation({ basepath: "/app" })
+    );
+
+    act(() => history.pushState(0, 0, "/app/dashboard"));
+    expect(result.current[0]).toBe("/dashboard");
+    unmount();
+  });
 });
 
 describe("`update` second parameter", () => {
@@ -97,6 +107,17 @@ describe("`update` second parameter", () => {
     const updateNow = result.current[1];
 
     expect(updateWas).toBe(updateNow);
+    unmount();
+  });
+
+  it("supports a basepath", () => {
+    const { result, unmount } = renderHook(() =>
+      useLocation({ basepath: "/app" })
+    );
+    const update = result.current[1];
+
+    act(() => update("/dashboard"));
+    expect(location.pathname).toBe("/app/dashboard");
     unmount();
   });
 });

--- a/test/use-location.test.js
+++ b/test/use-location.test.js
@@ -55,6 +55,16 @@ describe("`value` first argument", () => {
     expect(result.current[0]).toBe("/dashboard");
     unmount();
   });
+
+  it("returns `/` when URL contains only a basepath", () => {
+    const { result, unmount } = renderHook(() =>
+      useLocation({ basepath: "/app" })
+    );
+
+    act(() => history.pushState(0, 0, "/app"));
+    expect(result.current[0]).toBe("/");
+    unmount();
+  });
 });
 
 describe("`update` second parameter", () => {

--- a/use-location.js
+++ b/use-location.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "./react-deps.js";
 
-export default () => {
-  const [path, update] = useState(location.pathname);
+export default ({ basepath }) => {
+  const [path, update] = useState(location.pathname.slice(basepath.length));
   const prevPath = useRef(path);
 
   useEffect(() => {
@@ -11,9 +11,12 @@ export default () => {
     // last render and updates the state only when needed.
     // unfortunately, we can't rely on `path` value here, since it can be stale,
     // that's why we store the last pathname in a ref.
-    const checkForUpdates = () =>
-      prevPath.current !== location.pathname &&
-      update((prevPath.current = location.pathname));
+    const checkForUpdates = () => {
+      const pathname = location.pathname.slice(basepath.length);
+      return (
+        prevPath.current !== pathname && update((prevPath.current = pathname))
+      );
+    };
 
     const events = ["popstate", "pushState", "replaceState"];
     events.map(e => addEventListener(e, checkForUpdates));
@@ -31,10 +34,9 @@ export default () => {
   //
   // the function reference should stay the same between re-renders, so that
   // it can be passed down as an element prop without any performance concerns.
-  const navigate = useCallback(
-    (to, replace) => history[replace ? "replaceState" : "pushState"](0, 0, to),
-    []
-  );
+  const navigate = useCallback((to, replace) => {
+    return history[replace ? "replaceState" : "pushState"](0, 0, basepath + to);
+  }, []);
 
   return [path, navigate];
 };

--- a/use-location.js
+++ b/use-location.js
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from "./react-deps.js";
 
-export default (options = {}) => {
-  const { basepath = "" } = options;
+export default ({ basepath = "" } = {}) => {
   const [path, update] = useState(currentPathname(basepath));
   const prevPath = useRef(path);
 
@@ -14,9 +13,7 @@ export default (options = {}) => {
     // that's why we store the last pathname in a ref.
     const checkForUpdates = () => {
       const pathname = currentPathname(basepath);
-      return (
-        prevPath.current !== pathname && update((prevPath.current = pathname))
-      );
+      prevPath.current !== pathname && update((prevPath.current = pathname));
     };
 
     const events = ["popstate", "pushState", "replaceState"];
@@ -35,9 +32,11 @@ export default (options = {}) => {
   //
   // the function reference should stay the same between re-renders, so that
   // it can be passed down as an element prop without any performance concerns.
-  const navigate = useCallback((to, replace) => {
-    return history[replace ? "replaceState" : "pushState"](0, 0, basepath + to);
-  }, []);
+  const navigate = useCallback(
+    (to, replace) =>
+      history[replace ? "replaceState" : "pushState"](0, 0, basepath + to),
+    []
+  );
 
   return [path, navigate];
 };

--- a/use-location.js
+++ b/use-location.js
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState, useCallback } from "./react-deps.js";
 
-export default (router = {}) => {
-  const { basepath = "" } = router;
-  const [path, update] = useState(location.pathname.slice(basepath.length));
+export default (options = {}) => {
+  const { basepath = "" } = options;
+  const [path, update] = useState(currentPathname(basepath));
   const prevPath = useRef(path);
 
   useEffect(() => {
@@ -13,7 +13,7 @@ export default (router = {}) => {
     // unfortunately, we can't rely on `path` value here, since it can be stale,
     // that's why we store the last pathname in a ref.
     const checkForUpdates = () => {
-      const pathname = location.pathname.slice(basepath.length);
+      const pathname = currentPathname(basepath);
       return (
         prevPath.current !== pathname && update((prevPath.current = pathname))
       );
@@ -68,3 +68,6 @@ const patchHistoryEvents = () => {
 
   return (patched = 1);
 };
+
+const currentPathname = (base, path = location.pathname) =>
+  !path.indexOf(base) ? path.slice(base.length) || "/" : path;

--- a/use-location.js
+++ b/use-location.js
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "./react-deps.js";
 
-export default ({ basepath }) => {
+export default (router = {}) => {
+  const { basepath = "" } = router;
   const [path, update] = useState(location.pathname.slice(basepath.length));
   const prevPath = useRef(path);
 


### PR DESCRIPTION
Added super-basic support of `basepath` option.

There are two ways to setup a basepath:
- Global: `<Router basepath="/app">`
- Single location: `useLocation({ basepath: '/app' })`

### Common example
```jsx
<Router basepath="/app">
  <Link to="/">Index</Link>
  <Link to="/about">About Us</Link>

  <Route path="/">Index</Route>
  <Route path="/about">About Us</Route>
</Router>
```