### PR TITLE
Implement `strict` option on Route and useRoute

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ const AnimatedRoute = () => {
 };
 ```
 
+`useRoute` accepts a `options` object as a second argument which has these options:
+
+ - `strict` When enabled, a trailing slash in the pattern will only match when the path also has a trailing slash.
+
 ### `useLocation` hook: working with the history
 
 The low-level navigation in wouter is powered by the `useLocation` hook, which is basically a wrapper around
@@ -183,11 +187,11 @@ const Custom = () => {
 
 ## Component API
 
-### `<Route path={pattern} />`
+### `<Route path={pattern} strict={false}/>`
 
 `Route` represents a piece of the app that is rendered conditionally based on a pattern. Pattern is a string, which may
 contain special characters to describe dynamic segments, see [**Matching Dynamic Segments** section](#matching-dynamic-segments)
-below for details.
+below for details. When `strict` is enabled, a trailing slash in the pattern will only match when the path also has a trailing slash.
 
 The library provides multiple ways to declare a route's body:
 
@@ -274,7 +278,7 @@ A router is a simple object that holds the routing configuration options. You ca
 
 Read more → [Customizing the location hook](#customizing-the-location-hook).
 
-- **`matcher: (pattern: string, path: string) => [match: boolean, params: object]`** — a custom function used for matching the current location against the user-defined patterns like `/app/users/:id`. Should return a match result and an hash of extracted parameters.
+- **`matcher: (pattern: string, path: string, options: Object) => [match: boolean, params: object]`** — a custom function used for matching the current location against the user-defined patterns like `/app/users/:id`. Should return a match result and an hash of extracted parameters.
 
 - **`base: string`** — an optional setting that allows to specify a base path, such as `/app`. All application routes
   will be relative to that path.
@@ -364,7 +368,7 @@ import { Switch, Route } from "wouter";
 
 ### How do I make a link active for the current route?
 
-There are cases when you need to highlight an active link, for example, in the navigation bar. While this functionality isn't provided out-of-the-box, you can easily write your own `<Link />` wrapper and detect if the path is active by using the `useRoute` hook. The `useRoute(pattern)` hook returns a pair of `[match, params]`, where `match` is a boolean value that tells if the pattern matches current location:
+There are cases when you need to highlight an active link, for example, in the navigation bar. While this functionality isn't provided out-of-the-box, you can easily write your own `<Link />` wrapper and detect if the path is active by using the `useRoute` hook. The `useRoute(pattern, options)` hook returns a pair of `[match, params]`, where `match` is a boolean value that tells if the pattern matches current location:
 
 ```js
 const [isActive] = useRoute(props.href);

--- a/index.js
+++ b/index.js
@@ -41,9 +41,9 @@ export const useLocation = () => {
   return router.hook(router);
 };
 
-export const useRoute = pattern => {
+export const useRoute = (pattern, {strict = false} = {}) => {
   const [path] = useLocation();
-  return useRouter().matcher(pattern, path);
+  return useRouter().matcher(pattern, path, {strict});
 };
 
 /*
@@ -64,8 +64,8 @@ export const Router = props => {
   });
 };
 
-export const Route = ({ path, match, component, children }) => {
-  const useRouteMatch = useRoute(path);
+export const Route = ({ path, match, strict, component, children }) => {
+  const useRouteMatch = useRoute(path, {strict});
 
   // `props.match` is present - Route is controlled by the Switch
   const [matches, params] = match || useRouteMatch;
@@ -129,7 +129,7 @@ export const Switch = ({ children, location }) => {
       // this allows to use different components that wrap Route
       // inside of a switch, for example <AnimatedRoute />.
       (match = element.props.path
-        ? matcher(element.props.path, location || originalLocation)
+        ? matcher(element.props.path, location || originalLocation, {strict: element.props.strict})
         : [true, {}]
       )[0]
     )

--- a/test/matcher.test.js
+++ b/test/matcher.test.js
@@ -57,6 +57,15 @@ it("ignores a slash at the end", () => {
   expect(match("/orders/new/", "/orders/new")[0]).toBe(false);
 });
 
+it("respects a slash at the end when strict", () => {
+  const match = createMatcher();
+
+  expect(match("/orders/new", "/orders/new", {strict: true})[0]).toBe(true);
+  expect(match("/orders/new", "/orders/new/", {strict: true})[0]).toBe(false);
+  expect(match("/orders/new/", "/orders/new/", {strict: true})[0]).toBe(true);
+  expect(match("/orders/new/", "/orders/new", {strict: true})[0]).toBe(false);
+});
+
 describe("additional segment modifiers", () => {
   it("an asterisk matches 0 or more groups", () => {
     const match = createMatcher();

--- a/test/ssr.test.js
+++ b/test/ssr.test.js
@@ -5,7 +5,7 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { Route, Router, useRoute, Link } from "../index";
+import { Route, Router, useRoute, Link, Switch } from "../index";
 import staticLocationHook from "../static-location.js";
 
 describe("server-side rendering", () => {
@@ -50,5 +50,53 @@ describe("server-side rendering", () => {
 
     const rendered = renderToStaticMarkup(<App />);
     expect(rendered).toBe(`<a href="/users/1" title="Profile">Mark</a>`);
+  });
+
+  it("handles strict routes with useRoute", () => {
+    const HookRouteNoSlash = () => {
+      const [match] = useRoute("/pages/:name", {strict: true});
+      return match ? "NoSlash!" : null;
+    };
+
+    const HookRouteSlash = () => {
+      const [match] = useRoute("/pages/:name/", {strict: true});
+      return match ? "Slash!" : null;
+    };
+
+    const App = () => (
+      <Router hook={staticLocationHook("/pages/intro/")}>
+        <HookRouteNoSlash />
+        <HookRouteSlash />
+      </Router>
+    );
+
+    const rendered = renderToStaticMarkup(<App />);
+    expect(rendered).toBe("Slash!");
+  });
+
+  it("handles strict routes without Switch", () => {
+    const App = () => (
+      <Router hook={staticLocationHook("/foo/")}>
+        <Route strict path="/foo">NoSlash!</Route>
+        <Route strict path="/foo/">Slash!</Route>
+      </Router>
+    );
+
+    const rendered = renderToStaticMarkup(<App />);
+    expect(rendered).toBe("Slash!");
+  });
+
+  it("handles strict routes with Switch", () => {
+    const App = () => (
+      <Router hook={staticLocationHook("/foo/")}>
+        <Switch>
+          <Route strict path="/foo">NoSlash!</Route>
+          <Route strict path="/foo/">Slash!</Route>
+        </Switch>
+      </Router>
+    );
+
+    const rendered = renderToStaticMarkup(<App />);
+    expect(rendered).toBe("Slash!");
   });
 });


### PR DESCRIPTION
This implements the `strict` option from `react-router` which is useful when trailing slashes are significant to the application. The option takes the form of a new options object on `useRoute` and a plain component property on `<Route>`.

Fixes: https://github.com/molefrog/wouter/issues/106