### PR TITLE
Navigation options

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ import {
   createContext,
   isValidElement,
   cloneElement,
-  createElement as h
+  createElement as h,
 } from "./react-deps.js";
 
 /*
@@ -25,7 +25,7 @@ const RouterCtx = createContext({});
 const buildRouter = ({
   hook = locationHook,
   base = "",
-  matcher = makeMatcher()
+  matcher = makeMatcher(),
 } = {}) => ({ hook, base, matcher });
 
 export const useRouter = () => {
@@ -41,7 +41,7 @@ export const useLocation = () => {
   return router.hook(router);
 };
 
-export const useRoute = pattern => {
+export const useRoute = (pattern) => {
   const [path] = useLocation();
   return useRouter().matcher(pattern, path);
 };
@@ -50,7 +50,7 @@ export const useRoute = pattern => {
  * Part 2, Low Carb Router API: Router, Route, Link, Switch
  */
 
-export const Router = props => {
+export const Router = (props) => {
   const ref = useRef(null);
 
   // this little trick allows to avoid having unnecessary
@@ -60,7 +60,7 @@ export const Router = props => {
 
   return h(RouterCtx.Provider, {
     value: value,
-    children: props.children
+    children: props.children,
   });
 };
 
@@ -79,15 +79,14 @@ export const Route = ({ path, match, component, children }) => {
   return typeof children === "function" ? children(params) : children;
 };
 
-export const Link = props => {
+export const Link = (props) => {
+  let { to, href = to, children, onClick } = props;
+
   const [, navigate] = useLocation();
   const { base } = useRouter();
 
-  const href = props.href || props.to;
-  const { children, onClick } = props;
-
   const handleClick = useCallback(
-    event => {
+    (event) => {
       // ignores the navigation when clicked using right mouse button or
       // by holding a special modifier key: ctrl, command, win, alt, shift
       if (
@@ -100,7 +99,7 @@ export const Link = props => {
         return;
 
       event.preventDefault();
-      navigate(href);
+      navigate(href, props);
       onClick && onClick(event);
     },
     [href, onClick, navigate]
@@ -130,8 +129,7 @@ export const Switch = ({ children, location }) => {
       // inside of a switch, for example <AnimatedRoute />.
       (match = element.props.path
         ? matcher(element.props.path, location || originalLocation)
-        : [true, {}]
-      )[0]
+        : [true, {}])[0]
     )
       return cloneElement(element, { match });
   }
@@ -139,10 +137,10 @@ export const Switch = ({ children, location }) => {
   return null;
 };
 
-export const Redirect = props => {
+export const Redirect = (props) => {
   const [, push] = useLocation();
   useLayoutEffect(() => {
-    push(props.href || props.to, props.replace);
+    push(props.href || props.to, props);
 
     // we pass an empty array of dependecies to ensure that
     // we only run the effect once after initial render

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -58,7 +58,7 @@ it("supports `to` prop as an alias to `href`", () => {
 });
 
 it("performs a navigation when the link is clicked", () => {
-  const { container, getByTestId } = render(
+  const { getByTestId } = render(
     <Link href="/goo-baz">
       <a data-testid="link" />
     </Link>
@@ -67,8 +67,22 @@ it("performs a navigation when the link is clicked", () => {
   expect(location.pathname).toBe("/goo-baz");
 });
 
+it("supports replace navigation", () => {
+  const { getByTestId } = render(
+    <Link href="/goo-baz" replace>
+      <a data-testid="link" />
+    </Link>
+  );
+
+  const histBefore = history.length;
+
+  fireEvent.click(getByTestId("link"));
+  expect(location.pathname).toBe("/goo-baz");
+  expect(history.length).toBe(histBefore);
+});
+
 it("ignores the navigation when clicked with modifiers", () => {
-  const { container, getByTestId } = render(
+  const { getByTestId } = render(
     <Link href="/users" data-testid="link">
       click
     </Link>
@@ -79,7 +93,7 @@ it("ignores the navigation when clicked with modifiers", () => {
       bubbles: true,
       cancelable: true,
       button: 0,
-      ctrlKey: true
+      ctrlKey: true,
     })
   );
   expect(location.pathname).not.toBe("/users");
@@ -88,7 +102,7 @@ it("ignores the navigation when clicked with modifiers", () => {
 it("accepts an `onClick` prop, fired after the navigation", () => {
   const clickHandler = jest.fn();
 
-  const { container, getByTestId } = render(
+  const { getByTestId } = render(
     <Link href="/" onClick={clickHandler}>
       <a data-testid="link" />
     </Link>

--- a/test/redirect.test.js
+++ b/test/redirect.test.js
@@ -15,3 +15,13 @@ it("results in change of current location", () => {
   expect(location.pathname).toBe("/users");
   unmount();
 });
+
+it("supports replace navigation", () => {
+  const histBefore = history.length;
+
+  const { unmount } = render(<Redirect to="/users" replace />);
+
+  expect(location.pathname).toBe("/users");
+  expect(history.length).toBe(histBefore);
+  unmount();
+});

--- a/test/use-location.test.js
+++ b/test/use-location.test.js
@@ -98,7 +98,7 @@ describe("`update` second parameter", () => {
     const update = result.current[1];
 
     const histBefore = history.length;
-    act(() => update("/foo", true));
+    act(() => update("/foo", { replace: true }));
 
     expect(history.length).toBe(histBefore);
     expect(location.pathname).toBe("/foo");

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,18 +7,33 @@ import {
   FunctionComponent,
   ComponentType,
   ReactElement,
-  ReactNode
+  ReactNode,
 } from "react";
 
 export type Path = string;
-export type PushCallback = (to: Path, replace?: boolean) => void;
-
-export type LocationTuple = [Path, PushCallback];
 
 export interface LocationHookOptions {
   base?: Path;
 }
-export type LocationHook = (options?: LocationHookOptions) => LocationTuple;
+
+export interface LocationHookNavigationOptions {
+  replace?: boolean;
+}
+
+export type PushCallback<N = LocationHookNavigationOptions> = (
+  to: Path,
+  options?: N
+) => void;
+
+export type LocationTuple<N = LocationHookNavigationOptions> = [
+  Path,
+  PushCallback<N>
+];
+
+export type LocationHook<
+  O = LocationHookOptions,
+  N = LocationHookNavigationOptions
+> = (options?: O) => LocationTuple<N>;
 
 export interface DefaultParams {
   [paramName: string]: string;
@@ -52,9 +67,10 @@ export function Route<T extends DefaultParams = DefaultParams>(
 ): ReactElement | null;
 // tslint:enable:no-unnecessary-generics
 
-export type NavigationalProps =
+export type NavigationalProps = (
   | { to: Path; href?: never }
-  | { href: Path; to?: never };
+  | { href: Path; to?: never }) &
+  LocationHookNavigationOptions;
 
 export type LinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> &
   NavigationalProps;
@@ -79,9 +95,11 @@ export interface RouterProps {
   base: Path;
   matcher: MatcherFn;
 }
-export const Router: FunctionComponent<Partial<RouterProps> & {
-  children: ReactNode;
-}>;
+export const Router: FunctionComponent<
+  Partial<RouterProps> & {
+    children: ReactNode;
+  }
+>;
 
 export function useRouter(): RouterProps;
 

--- a/types/type-specs.tsx
+++ b/types/type-specs.tsx
@@ -8,7 +8,7 @@ import {
   Router,
   Switch,
   useLocation,
-  useRoute
+  useRoute,
 } from "wouter";
 
 import useBrowserLocation from "wouter/use-location";
@@ -78,6 +78,10 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
 <Link href="/about" to="/app" children="" />; // $ExpectError
 <Link children="" />; // $ExpectError
 
+<Link href="/about" replace>
+  About
+</Link>;
+
 <Link href="/about">
   This is <i>awesome!</i>
 </Link>;
@@ -101,7 +105,7 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
 <Link
   href="/somewhere"
   children={null}
-  onDrag={event => {
+  onDrag={(event) => {
     event; // $ExpectType DragEvent<HTMLAnchorElement>
   }}
 />;
@@ -112,6 +116,7 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
 
 <Redirect to="/" />;
 <Redirect href="/" />;
+<Redirect href="/" replace />;
 
 <Redirect>something</Redirect>; // $ExpectError
 
@@ -157,7 +162,8 @@ const [] = useLocation({}); // $ExpectError
 
 setLocation(); // $ExpectError
 setLocation("/app");
-setLocation("/app", true);
+setLocation("/app", { replace: true });
+setLocation("/app", { unknownOption: true }); // $ExpectError
 
 useRoute(Symbol()); // $ExpectError
 useRoute(); // $ExpectError

--- a/use-location.js
+++ b/use-location.js
@@ -17,15 +17,15 @@ export default ({ base = "" } = {}) => {
     };
 
     const events = ["popstate", "pushState", "replaceState"];
-    events.map(e => addEventListener(e, checkForUpdates));
+    events.map((e) => addEventListener(e, checkForUpdates));
 
     // it's possible that an update has occurred between render and the effect handler,
     // so we run additional check on mount to catch these updates. Based on:
     // https://gist.github.com/bvaughn/e25397f70e8c65b0ae0d7c90b731b189
     checkForUpdates();
 
-    return () => events.map(e => removeEventListener(e, checkForUpdates));
-  }, []);
+    return () => events.map((e) => removeEventListener(e, checkForUpdates));
+  }, [base]);
 
   // the 2nd argument of the `useLocation` return value is a function
   // that allows to perform a navigation.
@@ -33,9 +33,9 @@ export default ({ base = "" } = {}) => {
   // the function reference should stay the same between re-renders, so that
   // it can be passed down as an element prop without any performance concerns.
   const navigate = useCallback(
-    (to, replace) =>
+    (to, { replace = false } = {}) =>
       history[replace ? "replaceState" : "pushState"](0, 0, base + to),
-    []
+    [base]
   );
 
   return [path, navigate];
@@ -52,7 +52,7 @@ let patched = 0;
 const patchHistoryEvents = () => {
   if (patched) return;
 
-  ["pushState", "replaceState"].map(type => {
+  ["pushState", "replaceState"].map((type) => {
     const original = history[type];
 
     history[type] = function() {


### PR DESCRIPTION
This PR:
- Adds support for `replace` to `Link` and `Redirect`
- Makes it possible for external libraries to define their own navigational options. Example:

```js
import useLocationWithState from '@wouter/use-location-state';

const App = () => (
  <Router hook={useLocationWithState}>
    <Link to="/app" state={{ foo: 'bar' }}>Click Me</Link>
  </Router>
);
```

Next steps: the proper types are still WIP.