### PR TITLE
Add static location hook history [#113]

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,33 @@ const handleRequest = (req, res) => {
 
 Make sure you replace the static hook with the real one when you hydrate your app on a client.
 
+If you want to be able to detect redirects you can provide the `record` option:
+
+```js
+import { renderToString } from "react-dom/server";
+import { Router } from "wouter";
+import staticLocationHook from "wouter/static-location";
+
+import App from "./app";
+
+const handleRequest = (req, res) => {
+  const location = staticLocationHook(req.path, { record: true });
+  const prerendered = renderToString(
+    <Router hook={location}>
+      <App />
+    </Router>
+  );
+
+  // location.history is an array matching the history a
+  // user's browser would capture after loading the page
+
+  const finalPage = locationHook.history.slice(-1)[0];
+  if (finalPage !== req.path) {
+    // perform redirect
+  }
+};
+```
+
 ### 1KB is too much, I can't afford it!
 
 We've got some great news for you! If you're a minimalist bundle-size nomad and you need a damn simple

--- a/static-location.js
+++ b/static-location.js
@@ -1,4 +1,17 @@
 // Generates static `useLocation` hook. The hook always
 // responds with initial path provided.
 // You can use this for server-side rendering.
-module.exports = (path = "/") => () => [path, x => x];
+export default (path = "/", { record = false } = {}) => {
+  let hook;
+  const navigate = (to, { replace } = {}) => {
+    if (record) {
+      if (replace) {
+        hook.history.pop();
+      }
+      hook.history.push(to);
+    }
+  };
+  hook = () => [path, navigate];
+  hook.history = [path];
+  return hook;
+};

--- a/test/static-location.test.js
+++ b/test/static-location.test.js
@@ -24,3 +24,41 @@ it("doesn't change the value even if updated", () => {
 
   expect(result.current[0]).toBe("/try-changing-me");
 });
+
+it("records no history by default", () => {
+  const hook = staticLocation("/page1");
+  const { result } = renderHook(() => hook());
+  const [, update] = result.current;
+
+  act(() => {
+    update("/page2");
+  });
+
+  expect(hook.history).toEqual(["/page1"]);
+});
+
+it("records history if requested but does not change the value", () => {
+  const hook = staticLocation("/page1", { record: true });
+  const { result } = renderHook(() => hook());
+  const [, update] = result.current;
+
+  act(() => {
+    update("/page2");
+  });
+
+  expect(hook.history).toEqual(["/page1", "/page2"]);
+  expect(result.current[0]).toBe("/page1");
+});
+
+it("respects the 'replace' option", () => {
+  const hook = staticLocation("/page1", { record: true });
+  const { result } = renderHook(() => hook());
+  const [, update] = result.current;
+
+  act(() => {
+    update("/page2", { replace: true });
+  });
+
+  expect(hook.history).toEqual(["/page2"]);
+  expect(result.current[0]).toBe("/page1");
+});

--- a/types/static-location.d.ts
+++ b/types/static-location.d.ts
@@ -1,5 +1,16 @@
 import { Path, LocationHook } from "./index";
 
-declare function staticLocationHook(path?: Path): LocationHook;
+interface StaticLocationHookOptions {
+  record?: boolean;
+}
 
-export = staticLocationHook;
+interface StaticLocationHook extends LocationHook {
+  history: Readonly<Path[]>;
+}
+
+declare function staticLocationHook(
+  path?: Path,
+  options?: StaticLocationHookOptions,
+): StaticLocationHook;
+
+export default staticLocationHook;

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -5,7 +5,11 @@
     "noEmit": true,
     "strict": true,
     "baseUrl": ".",
-    "paths": { "wouter": ["."], "wouter/use-location": ["./use-location"] }
+    "paths": {
+      "wouter": ["."],
+      "wouter/use-location": ["./use-location"],
+      "wouter/static-location": ["./static-location"]
+    }
   },
   "files": ["./type-specs.tsx"]
 }

--- a/types/type-specs.tsx
+++ b/types/type-specs.tsx
@@ -12,6 +12,7 @@ import {
 } from "wouter";
 
 import useBrowserLocation from "wouter/use-location";
+import staticLocationHook from "wouter/static-location";
 
 const Header: React.FunctionComponent = () => <div />;
 const Profile = ({ params }: RouteComponentProps<{ id: string }>) => (
@@ -197,3 +198,19 @@ loc; // $ExpectType string
 
 useBrowserLocation({ base: "/something" });
 useBrowserLocation({ foo: "bar" }); // $ExpectError
+
+/*
+ * staticLocationHook
+ */
+
+const myStaticHook = staticLocationHook();
+const [staticLoc, staticNavigate] = myStaticHook();
+staticLoc; // $ExpectType string
+staticNavigate("/something");
+staticNavigate("/something", { replace: true });
+staticNavigate("/something", { foo: "bar" }); // $ExpectError
+myStaticHook.history; // $ExpectType readonly string[]
+
+staticLocationHook('/');
+staticLocationHook('/', { record: true });
+staticLocationHook('/', { foo: "bar" }); // $ExpectError


### PR DESCRIPTION
As discussed in #113. This adds `.history` to `staticLocationHook`.

This can be used for testing:

```js
const locationHook = staticLocationHook('/', { record: true });

const dom = render((
  <Router hook={locationHook}>
    <MyComponent />
  </Router>
), { queries });

// (click a link)

expect(locationHook.history).toEqual(['/', '/my-new-path']);
```

And can be used to perform automatic redirection when server-side rendering:

```js
const locationHook = staticLocationHook(requestedPage, { record: true });

const dom = render(<Router hook={locationHook}><App /></Router>);

const redirect = locationHook.history.slice(-1)[0];
if (redirect !== requestedPage) {
  return Redirect(redirect);
} else {
  return Ok(dom);
}
```

Notes:

- I didn't implement `dynamic`: when I looked at it properly, I found that it would need a lot more logic to make it work correctly with hooks (local state with detection of changes on the global state, similar to the existing code in `use-location.js`)
- This adds TypeScript definition tests to `static-location` which didn't exist before
- I noticed that this is not a drop-in replacement for the browser location hook because it doesn't implement `base`. I decided not to fix this since it is an existing unrelated bug (and fixing it would change behaviour whereas this PR maintains old behaviour unless the new option is specified).

More generally, I think `dynamic` and `base` should both be implemented by allowing more code to be shared from `use-location`. It feels like user-provided hooks could benefit from not having to worry about syncing global/local state. But I'm not sure what the best approach is there.