### PR TITLE
Dual ESM+CJS exports with subpath support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,27 @@
     "preact",
     "cjs"
   ],
-  "module": "index.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./cjs/index.js",
+      "default": "./index.js"
+    },
+    "./use-location": {
+      "require": "./cjs/use-location.js",
+      "default": "./use-location.js"
+    },
+    "./matcher": {
+      "require": "./cjs/matcher.js",
+      "default": "./matcher.js"
+    },
+    "./static-location": {
+      "require": "./cjs/static-location.js",
+      "default": "./static-location.js"
+    }
+  },
   "main": "cjs/index.js",
+  "module": "index.js",
   "types": "index.d.ts",
   "scripts": {
     "test": "jest --verbose --coverage",
@@ -26,7 +45,7 @@
     "lint-types": "npm run types-preact && dtslint types --onlyTestTsNext && dtslint types/preact --onlyTestTsNext",
     "types-react": "copyfiles -f types/*.d.ts .",
     "types-preact": "copyfiles -f {index,matcher,use-location,static-location}.js types/{matcher,use-location,static-location}.d.ts types/preact/*.d.ts preact/",
-    "bundle": "rollup -e react,preact,preact/hooks -f cjs --exports named --preserveModules -d ${DIR}cjs ${DIR}*.js && rollup -f cjs -d ${DIR}cjs ${DIR}static-location.js",
+    "bundle": "rollup -e react,preact,preact/hooks -f cjs --exports named --preserveModules -d ${DIR}cjs ${DIR}*.js && rollup -f cjs -d ${DIR}cjs ${DIR}static-location.js && echo '{\"type\": \"commonjs\"}' > ${DIR}cjs/package.json",
     "prepublishOnly": "npm run types-react && npm run types-preact && npm run bundle && DIR=./preact/ npm run bundle"
   },
   "author": "Alexey Taktarov <molefrog@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,11 @@
   "scripts": {
     "test": "jest --verbose --coverage",
     "size": "size-limit",
-    "lint-types": "npm run pack-preact && dtslint types --onlyTestTsNext && dtslint types/preact --onlyTestTsNext",
-    "pack-react": "copyfiles -f types/*.d.ts .",
-    "pack-preact": "copyfiles -f {index,matcher,use-location,static-location}.js types/{matcher,use-location,static-location}.d.ts types/preact/index.d.ts preact/",
-    "bundle-cjs": "rollup -e react,preact,preact/hooks -f cjs --exports named --preserveModules -d cjs *.js preact/*.js",
-    "bundle-cjs-preact": "rollup -e preact,preact/hooks -f cjs --exports named --preserveModules -d preact/cjs preact/*.js",
-    "prepublishOnly": "npm run pack-react && npm run pack-preact && npm run bundle-cjs && npm run bundle-cjs-preact"
+    "lint-types": "npm run types-preact && dtslint types --onlyTestTsNext && dtslint types/preact --onlyTestTsNext",
+    "types-react": "copyfiles -f types/*.d.ts .",
+    "types-preact": "copyfiles -f {index,matcher,use-location,static-location}.js types/{matcher,use-location,static-location}.d.ts types/preact/*.d.ts preact/",
+    "bundle": "rollup -e react,preact,preact/hooks -f cjs --exports named --preserveModules -d ${DIR}cjs ${DIR}*.js && rollup -f cjs -d ${DIR}cjs ${DIR}static-location.js",
+    "prepublishOnly": "npm run types-react && npm run types-preact && npm run bundle && DIR=./preact/ npm run bundle"
   },
   "author": "Alexey Taktarov <molefrog@gmail.com>",
   "license": "ISC",

--- a/preact/package.json
+++ b/preact/package.json
@@ -2,6 +2,25 @@
   "name": "wouter-preact",
   "version": "2.5.0",
   "description": "A minimalistic routing for React and Preact (Preact-only version).",
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./cjs/index.js",
+      "default": "./index.js"
+    },
+    "./use-location": {
+      "require": "./cjs/use-location.js",
+      "default": "./use-location.js"
+    },
+    "./matcher": {
+      "require": "./cjs/matcher.js",
+      "default": "./matcher.js"
+    },
+    "./static-location": {
+      "require": "./cjs/static-location.js",
+      "default": "./static-location.js"
+    }
+  },
   "main": "cjs/index.js",
   "module": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Closes #126 
- The type of the package is now `module`, which means it should work properly with `.mjs` scripts (unflagged support starting from Node 12.15.0)
- When used in `require` environments, a CJS variant will be used 
- `import from "wouter/matcher"` and `require("wouter/matcher")` now point to the ESM and CJS versions respectively. 
- The `static-location.js` is now transformed to CJS with `--exports default`, which allows to write:
```js
// in ESM 
import staticLocation from "wouter/static-location";

// in CJS
const staticLocation = require("wouter/static-location");
```

The long-term plan is to move towards ESM-only mode, but that's probably going to take some time until ESM is fully adopted by the Node community. Why ESM:
  - Supported by bundlers, enables proper tree-shaking
  - Will work in Deno, Snowpack
  - Will (hopefully) soon be adopted by Node projects
