### PR TITLE
Reuse & expose events

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ import {
   createElement as h,
 } from "./react-deps.js";
 
+/**
+ * consts
+ */
+export { eventsHistory } from "./use-location";
 /*
  * Part 1, Hooks API: useRouter, useRoute and useLocation
  */

--- a/index.js
+++ b/index.js
@@ -12,10 +12,6 @@ import {
   createElement as h,
 } from "./react-deps.js";
 
-/**
- * consts
- */
-export { eventsHistory } from "./use-location";
 /*
  * Part 1, Hooks API: useRouter, useRoute and useLocation
  */

--- a/use-location.js
+++ b/use-location.js
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState, useCallback } from "./react-deps.js";
 
+const eventPopState = "popstate"
+const eventPushState = "pushstate"
+const eventReplaceState = "replaceState"
+export const eventsHistory = [eventPopState, eventPushState, eventReplaceState]
+
 export default ({ base = "" } = {}) => {
   const [path, update] = useState(currentPathname(base));
   const prevPath = useRef(path);
@@ -16,8 +21,7 @@ export default ({ base = "" } = {}) => {
       prevPath.current !== pathname && update((prevPath.current = pathname));
     };
 
-    const events = ["popstate", "pushState", "replaceState"];
-    events.map((e) => addEventListener(e, checkForUpdates));
+    eventsHistory.map((e) => addEventListener(e, checkForUpdates));
 
     // it's possible that an update has occurred between render and the effect handler,
     // so we run additional check on mount to catch these updates. Based on:
@@ -34,7 +38,7 @@ export default ({ base = "" } = {}) => {
   // it can be passed down as an element prop without any performance concerns.
   const navigate = useCallback(
     (to, { replace = false } = {}) =>
-      history[replace ? "replaceState" : "pushState"](0, 0, base + to),
+      history[replace ? eventReplaceState : eventPushState](0, 0, base + to),
     [base]
   );
 
@@ -52,7 +56,7 @@ let patched = 0;
 const patchHistoryEvents = () => {
   if (patched) return;
 
-  ["pushState", "replaceState"].map((type) => {
+  [eventPushState, eventReplaceState].map((type) => {
     const original = history[type];
 
     history[type] = function() {

--- a/use-location.js
+++ b/use-location.js
@@ -3,10 +3,10 @@ import { useEffect, useRef, useState, useCallback } from "./react-deps.js";
 /**
  * History API docs @see https://developer.mozilla.org/en-US/docs/Web/API/History
  */
-const eventPopstate = "popstate"
-const eventPushState = "pushState"
-const eventReplaceState = "replaceState"
-export const eventsHistory = [eventPopstate, eventPushState, eventReplaceState]
+const eventPopstate = "popstate";
+const eventPushState = "pushState";
+const eventReplaceState = "replaceState";
+export const events = [eventPopstate, eventPushState, eventReplaceState];
 
 export default ({ base = "" } = {}) => {
   const [path, update] = useState(currentPathname(base));
@@ -24,7 +24,7 @@ export default ({ base = "" } = {}) => {
       prevPath.current !== pathname && update((prevPath.current = pathname));
     };
 
-    eventsHistory.map((e) => addEventListener(e, checkForUpdates));
+    events.map((e) => addEventListener(e, checkForUpdates));
 
     // it's possible that an update has occurred between render and the effect handler,
     // so we run additional check on mount to catch these updates. Based on:

--- a/use-location.js
+++ b/use-location.js
@@ -1,9 +1,12 @@
 import { useEffect, useRef, useState, useCallback } from "./react-deps.js";
 
-const eventPopState = "popstate"
-const eventPushState = "pushstate"
+/**
+ * History API docs @see https://developer.mozilla.org/en-US/docs/Web/API/History
+ */
+const eventPopstate = "popstate"
+const eventPushState = "pushState"
 const eventReplaceState = "replaceState"
-export const eventsHistory = [eventPopState, eventPushState, eventReplaceState]
+export const eventsHistory = [eventPopstate, eventPushState, eventReplaceState]
 
 export default ({ base = "" } = {}) => {
   const [path, update] = useState(currentPathname(base));


### PR DESCRIPTION
We stumbled upon a need to react on the same events wouter's `useLocation`, but outside of a hook & react itself.
For example, to clean up certain state from all components on history's state changes, but not notifying them about it.
- basically a case similar to useRef, but outside of react

This PR should decrease the bundle a tiny bit (or probably leave it the same, due to additional export) for an already tiny library :D
And let users to reuse some of the events, keeping wouter as a source of truth.