### PR TITLE
feat: basepath should be case-insensitive

### DIFF
--- a/test/use-location.test.js
+++ b/test/use-location.test.js
@@ -61,6 +61,14 @@ describe("`value` first argument", () => {
     expect(result.current[0]).toBe("/");
     unmount();
   });
+
+  it("bathpath should be case-insensitive", () => {
+    const { result, unmount } = renderHook(() => useLocation({ base: "/App" }));
+
+    act(() => history.pushState(0, 0, "/app/dashboard"));
+    expect(result.current[0]).toBe("/dashboard");
+    unmount();
+  });
 });
 
 describe("`update` second parameter", () => {

--- a/use-location.js
+++ b/use-location.js
@@ -9,7 +9,7 @@ const eventReplaceState = "replaceState";
 export const events = [eventPopstate, eventPushState, eventReplaceState];
 
 export default ({ base = "" } = {}) => {
-  const [path, update] = useState(currentPathname(base));
+  const [path, update] = useState(currPathname(base));
   const prevPath = useRef(path);
 
   useEffect(() => {
@@ -20,7 +20,7 @@ export default ({ base = "" } = {}) => {
     // unfortunately, we can't rely on `path` value here, since it can be stale,
     // that's why we store the last pathname in a ref.
     const checkForUpdates = () => {
-      const pathname = currentPathname(base);
+      const pathname = currPathname(base);
       prevPath.current !== pathname && update((prevPath.current = pathname));
     };
 
@@ -75,5 +75,5 @@ const patchHistoryEvents = () => {
   return (patched = 1);
 };
 
-const currentPathname = (base, path = location.pathname) =>
-  !path.indexOf(base) ? path.slice(base.length) || "/" : path;
+const currPathname = (base, path = location.pathname.toLowerCase()) =>
+  !path.indexOf(base.toLowerCase()) ? path.slice(base.length) || "/" : path;

--- a/use-location.js
+++ b/use-location.js
@@ -75,5 +75,5 @@ const patchHistoryEvents = () => {
   return (patched = 1);
 };
 
-const currentPathname = (base, path = location.pathname) =>
+const currentPathname = (base, path = location.pathname.toLowerCase()) =>
   !path.indexOf(base.toLowerCase()) ? path.slice(base.length) || "/" : path;

--- a/use-location.js
+++ b/use-location.js
@@ -9,7 +9,7 @@ const eventReplaceState = "replaceState";
 export const events = [eventPopstate, eventPushState, eventReplaceState];
 
 export default ({ base = "" } = {}) => {
-  const [path, update] = useState(currPathname(base));
+  const [path, update] = useState(currentPathname(base));
   const prevPath = useRef(path);
 
   useEffect(() => {
@@ -20,7 +20,7 @@ export default ({ base = "" } = {}) => {
     // unfortunately, we can't rely on `path` value here, since it can be stale,
     // that's why we store the last pathname in a ref.
     const checkForUpdates = () => {
-      const pathname = currPathname(base);
+      const pathname = currentPathname(base);
       prevPath.current !== pathname && update((prevPath.current = pathname));
     };
 
@@ -75,5 +75,5 @@ const patchHistoryEvents = () => {
   return (patched = 1);
 };
 
-const currPathname = (base, path = location.pathname.toLowerCase()) =>
+const currentPathname = (base, path = location.pathname) =>
   !path.indexOf(base.toLowerCase()) ? path.slice(base.length) || "/" : path;


### PR DESCRIPTION
hello, @molefrog 

The [wouter `matcher` is case-insensitive by default](https://github.com/molefrog/wouter/blob/master/matcher.js#L65), so the `basepath` should be case-insensitive default too ?

keep `pathname` and` basepath` with the same default behavior, so we can reducing user confusion. 

Of course, we can also provide a `sensitive` parameter, but it should be applied to `matcher` and `basepath` at the same time, otherwise, we will ignore case by default.

Do you have any suggestions？