### PR TITLE
fix: passing state & title to pushState & replaceState

### DIFF
--- a/test/preact.test.js
+++ b/test/preact.test.js
@@ -8,7 +8,7 @@ const { Route, Link, Switch } = require("../index.js");
 
 describe("Preact support", () => {
   beforeEach(() => {
-    history.replaceState(0, 0, "/");
+    history.replaceState(null, "", "/");
     setupRerender();
   });
 

--- a/test/switch.test.js
+++ b/test/switch.test.js
@@ -91,7 +91,7 @@ it("allows to specify which routes to render via `location` prop", () => {
 });
 
 it("always ensures the consistency of inner routes rendering", async () => {
-  history.replaceState(0, 0, "/foo/bar");
+  history.replaceState(null, "", "/foo/bar");
 
   const { unmount } = render(
     <Switch>
@@ -107,7 +107,7 @@ it("always ensures the consistency of inner routes rendering", async () => {
 
   await act(async () => {
     await raf();
-    history.pushState(0, 0, "/");
+    history.pushState(null, "", "/");
   });
 
   unmount();

--- a/test/use-location.test.js
+++ b/test/use-location.test.js
@@ -11,7 +11,7 @@ it("returns a pair [value, update]", () => {
 });
 
 describe("`value` first argument", () => {
-  beforeEach(() => history.replaceState(0, 0, "/"));
+  beforeEach(() => history.replaceState(null, "", "/"));
 
   it("reflects the current pathname", () => {
     const { result, unmount } = renderHook(() => useLocation());
@@ -22,10 +22,10 @@ describe("`value` first argument", () => {
   it("reacts to `pushState` / `replaceState`", () => {
     const { result, unmount } = renderHook(() => useLocation());
 
-    act(() => history.pushState(0, 0, "/foo"));
+    act(() => history.pushState(null, "", "/foo"));
     expect(result.current[0]).toBe("/foo");
 
-    act(() => history.replaceState(0, 0, "/bar"));
+    act(() => history.replaceState(null, "", "/bar"));
     expect(result.current[0]).toBe("/bar");
     unmount();
   });
@@ -34,7 +34,7 @@ describe("`value` first argument", () => {
     jest.useFakeTimers();
     const { result, unmount } = renderHook(() => useLocation());
 
-    act(() => history.pushState(0, 0, "/foo"));
+    act(() => history.pushState(null, "", "/foo"));
     expect(result.current[0]).toBe("/foo");
 
     act(() => {
@@ -49,7 +49,7 @@ describe("`value` first argument", () => {
   it("returns a pathname without a basepath", () => {
     const { result, unmount } = renderHook(() => useLocation({ base: "/app" }));
 
-    act(() => history.pushState(0, 0, "/app/dashboard"));
+    act(() => history.pushState(null, "", "/app/dashboard"));
     expect(result.current[0]).toBe("/dashboard");
     unmount();
   });
@@ -57,7 +57,7 @@ describe("`value` first argument", () => {
   it("returns `/` when URL contains only a basepath", () => {
     const { result, unmount } = renderHook(() => useLocation({ base: "/app" }));
 
-    act(() => history.pushState(0, 0, "/app"));
+    act(() => history.pushState(null, "", "/app"));
     expect(result.current[0]).toBe("/");
     unmount();
   });
@@ -65,7 +65,7 @@ describe("`value` first argument", () => {
   it("bathpath should be case-insensitive", () => {
     const { result, unmount } = renderHook(() => useLocation({ base: "/App" }));
 
-    act(() => history.pushState(0, 0, "/app/dashboard"));
+    act(() => history.pushState(null, "", "/app/dashboard"));
     expect(result.current[0]).toBe("/dashboard");
     unmount();
   });

--- a/use-location.js
+++ b/use-location.js
@@ -41,7 +41,7 @@ export default ({ base = "" } = {}) => {
   // it can be passed down as an element prop without any performance concerns.
   const navigate = useCallback(
     (to, { replace = false } = {}) =>
-      history[replace ? eventReplaceState : eventPushState](0, 0, base + to),
+      history[replace ? eventReplaceState : eventPushState](null, "", base + to),
     [base]
   );
 


### PR DESCRIPTION
Fixes #142 

As #142 describes, this PR corrects `state` & `title` params for `pushState` & `replaceState` to the recommended `falsy` ones `null` for `state` & `""` for `title` 