### PR TITLE
feat: take Fragments and Arrays into account for Switch

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,9 +143,7 @@ export const Switch = ({ children, location }) => {
   const { matcher } = useRouter();
   const [originalLocation] = useLocation();
 
-  children = flattenChildren(children);
-
-  for (const element of children) {
+  for (const element of flattenChildren(children)) {
     let match = 0;
 
     if (

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ import {
   isValidElement,
   cloneElement,
   createElement as h,
+  Fragment,
 } from "./react-deps.js";
 
 /*
@@ -128,11 +129,21 @@ export const Link = (props) => {
   return cloneElement(jsx, extraProps);
 };
 
+const flattenChildren = (children) => {
+  return Array.isArray(children)
+    ? children.flatMap((c) =>
+        c.type === Fragment
+          ? flattenChildren(c.props.children)
+          : flattenChildren(c)
+      )
+    : [children];
+};
+
 export const Switch = ({ children, location }) => {
   const { matcher } = useRouter();
   const [originalLocation] = useLocation();
 
-  children = Array.isArray(children) ? children : [children];
+  children = flattenChildren(children);
 
   for (const element of children) {
     let match = 0;

--- a/index.js
+++ b/index.js
@@ -131,10 +131,12 @@ export const Link = (props) => {
 
 const flattenChildren = (children) => {
   return Array.isArray(children)
-    ? children.flatMap((c) =>
-        c.type === Fragment
-          ? flattenChildren(c.props.children)
-          : flattenChildren(c)
+    ? [].concat(
+        ...children.map((c) =>
+          c.type === Fragment
+            ? flattenChildren(c.props.children)
+            : flattenChildren(c)
+        )
       )
     : [children];
 };

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "1375 B"
+      "limit": "1373 B"
     },
     {
       "path": "use-location.js",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "1339 B"
+      "limit": "1375 B"
     },
     {
       "path": "use-location.js",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "1373 B"
+      "limit": "1378 B"
     },
     {
       "path": "use-location.js",

--- a/preact/react-deps.js
+++ b/preact/react-deps.js
@@ -3,6 +3,7 @@ export {
   createContext,
   cloneElement,
   createElement,
+  Fragment,
 } from "preact";
 export {
   useRef,

--- a/react-deps.js
+++ b/react-deps.js
@@ -9,4 +9,5 @@ export {
   isValidElement,
   cloneElement,
   createElement,
+  Fragment,
 } from "react";

--- a/test/switch.test.js
+++ b/test/switch.test.js
@@ -157,7 +157,7 @@ it("correctly handles arrays as children", async () => {
       {[1, 2, 3].map((i) => {
         const H = "h" + i;
         return (
-          <Route path={"/in-array-" + i}>
+          <Route key={i} path={"/in-array-" + i}>
             <H />
           </Route>
         );
@@ -182,7 +182,7 @@ it("correctly handles fragments as children", async () => {
         {[1, 2, 3].map((i) => {
           const H = "h" + i;
           return (
-            <Route path={"/in-fragment-" + i}>
+            <Route key={i} path={"/in-fragment-" + i}>
               <H />
             </Route>
           );

--- a/test/switch.test.js
+++ b/test/switch.test.js
@@ -149,3 +149,53 @@ it("uses a route without a path prop as a fallback", async () => {
   expect(rendered.length).toBe(1);
   expect(result.findByType("h2")).toBeTruthy();
 });
+
+it("correctly handles arrays as children", async () => {
+  const result = testRouteRender(
+    "/in-array-3",
+    <Switch>
+      {[1, 2, 3].map((i) => {
+        const H = "h" + i;
+        return (
+          <Route path={"/in-array-" + i}>
+            <H />
+          </Route>
+        );
+      })}
+      <Route>
+        <h4 />
+      </Route>
+    </Switch>
+  );
+
+  const rendered = result.children[0].children;
+
+  expect(rendered.length).toBe(1);
+  expect(result.findByType("h3")).toBeTruthy();
+});
+
+it("correctly handles fragments as children", async () => {
+  const result = testRouteRender(
+    "/in-fragment-2",
+    <Switch>
+      <>
+        {[1, 2, 3].map((i) => {
+          const H = "h" + i;
+          return (
+            <Route path={"/in-fragment-" + i}>
+              <H />
+            </Route>
+          );
+        })}
+      </>
+      <Route>
+        <h4 />
+      </Route>
+    </Switch>
+  );
+
+  const rendered = result.children[0].children;
+
+  expect(rendered.length).toBe(1);
+  expect(result.findByType("h2")).toBeTruthy();
+});


### PR DESCRIPTION
This PR fixes #154.

I open it in case the ideas discussed in #154 are accepted. This adds a `flattenChildren` method used inside the `Switch` component to gracefully handle Arrays and Fragments as children of Switch. This opens up nicer patterns for static fallback routes with dynamically defined siblings.

This PR also adds two tests for the Switch component, validating its handling of Arrays and Fragments.