### PR TITLE
Simplify code example of hash-based routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ If you do need a custom history observer, for example, for hash-based routing, y
 As an exercise, let's implement a simple location hook that listens to hash changes:
 
 ```js
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { Router, Route } from "wouter";
 
 // returns the current hash location in a normalized form
@@ -182,6 +182,8 @@ import { Router, Route } from "wouter";
 const currentLocation = () => {
   return window.location.hash.replace(/^#/, "") || "/";
 };
+
+const navigate = (to) => (window.location.hash = to);
 
 const useHashLocation = () => {
   const [loc, setLoc] = useState(currentLocation());
@@ -194,10 +196,6 @@ const useHashLocation = () => {
     window.addEventListener("hashchange", handler);
     return () => window.removeEventListener("hashchange", handler);
   }, []);
-
-  // remember to wrap your function with `useCallback` hook
-  // a tiny but important optimization
-  const navigate = useCallback((to) => (window.location.hash = to), []);
 
   return [loc, navigate];
 };


### PR DESCRIPTION
The `navigate` function can be moved outside the function component since it doesn't have any dependencies.