### PR TITLE
Fix rerender when location.search changes

### DIFF
--- a/test/use-location.test.js
+++ b/test/use-location.test.js
@@ -85,15 +85,29 @@ describe("`value` first argument", () => {
   it("supports search url", () => {
     const { result, unmount } = renderHook(() => useLocation());
 
+    expect(result.current[0]).toBe("/");
+    expect(result.all.length).toBe(1);
+
     act(() => history.pushState(null, "", "/foo"));
 
-    const renderCount = result.all.length;
+    expect(result.current[0]).toBe("/foo");
+    expect(result.all.length).toBe(2);
+
+    act(() => history.pushState(null, "", "/foo"));
+
+    expect(result.current[0]).toBe("/foo");
+    expect(result.all.length).toBe(2); // no re-render
+
     act(() => history.pushState(null, "", "/foo?hello=world"));
 
     expect(result.current[0]).toBe("/foo");
+    expect(result.all.length).toBe(3);
 
-    // assert the update
-    expect(result.all.length).toBeGreaterThan(renderCount);
+    act(() => history.pushState(null, "", "/foo?goodbye=world"));
+
+    expect(result.current[0]).toBe("/foo");
+    expect(result.all.length).toBe(4);
+
     unmount();
   });
 });

--- a/use-location.js
+++ b/use-location.js
@@ -9,8 +9,11 @@ const eventReplaceState = "replaceState";
 export const events = [eventPopstate, eventPushState, eventReplaceState];
 
 export default ({ base = "" } = {}) => {
-  const [path, update] = useState(() => currentPathname(base)); // @see https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
-  const prevHash = useRef(path + location.search);
+  const [pathAndSearch, update] = useState(() => ({
+    path: currentPathname(base),
+    search: location.search,
+  })); // @see https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const prevHash = useRef(pathAndSearch.path + pathAndSearch.search);
 
   useEffect(() => {
     // this function checks if the location has been changed since the
@@ -18,12 +21,13 @@ export default ({ base = "" } = {}) => {
     // unfortunately, we can't rely on `path` value here, since it can be stale,
     // that's why we store the last pathname in a ref.
     const checkForUpdates = () => {
-      const pathname = currentPathname(base),
-        hash = pathname + location.search;
+      const pathname = currentPathname(base);
+      const search = location.search;
+      const hash = pathname + search;
 
       if (prevHash.current !== hash) {
         prevHash.current = hash;
-        update(pathname);
+        update({ path: pathname, search: search });
       }
     };
 
@@ -53,7 +57,7 @@ export default ({ base = "" } = {}) => {
     [base]
   );
 
-  return [path, navigate];
+  return [pathAndSearch.path, navigate];
 };
 
 // While History API does have `popstate` event, the only


### PR DESCRIPTION
18a3a38e7c7f5e7451ffb30addfef08123050d8c removed the search from the pathname returned from useLocation, but that caused a bug because useState has an optimization that it can avoid a re-render if the state has not changed.  Since only the path and not the search was set in the state, React avoids a re-render when only the search changes.

https://reactjs.org/docs/hooks-reference.html#bailing-out-of-a-dispatch

Unfortunately, the test suite didn't pick that up because I suspect there is a difference between the react-testing-renderer and the real browser renderer. I have been trying and logging various re-renders in real React and react-testing-renderer. For whatever reason in the test suite, which uses react-testing-renderer, React does re-render the first time useState is called with the duplicate value, which I suspect is something to do with fibers.  This difference caused the test suite to pass even though the real react skips the first update.

Eventually the react-testing-renderer does also stop re-rendering, so it is still possible to include in the test suite.  The update
to "/foo?goodbye=world" is the one that fails in the test suite and does not cause a re-render.

To fix, I just include both the path and search in the state so that when the state is updated, it is always re-rendered.  There is the check using the ref to prevent re-rendering, so by the time update is called, we know we need a re-render.

----

All this is orthogonal to the question of exposing the search values directly in the API somewhere.  For myself, while it would be nice to have the search params available in the API somewhere, I am just fine parsing them myself.  All I need is for the re-render to occur when it changes.