### PR TITLE
Add correct return type to `makeRegexpFn`

### DIFF
--- a/types/matcher.d.ts
+++ b/types/matcher.d.ts
@@ -20,14 +20,13 @@ export type Match<T extends DefaultParams = DefaultParams> =
 
 export type MatcherFn = (pattern: Path, path: Path) => Match;
 
-export type MakeRegexpFn = {
+export type PatternToRegexpResult = {
   keys: Array<{ name: string | number }>;
-  regexp: RegExp;
 };
 
 export default function makeMatcher(
   makeRegexpFn?: (
     pattern: string,
     keys?: Array<{ name: string | number }>
-  ) => MakeRegexpFn
+  ) => PatternToRegexpResult
 ): MatcherFn;

--- a/types/matcher.d.ts
+++ b/types/matcher.d.ts
@@ -22,11 +22,9 @@ export type MatcherFn = (pattern: Path, path: Path) => Match;
 
 export type PatternToRegexpResult = {
   keys: Array<{ name: string | number }>;
+  regexp: RegExp;
 };
 
 export default function makeMatcher(
-  makeRegexpFn?: (
-    pattern: string,
-    keys?: Array<{ name: string | number }>
-  ) => PatternToRegexpResult
+  makeRegexpFn?: (pattern: string) => PatternToRegexpResult
 ): MatcherFn;

--- a/types/matcher.d.ts
+++ b/types/matcher.d.ts
@@ -20,7 +20,7 @@ export type Match<T extends DefaultParams = DefaultParams> =
 
 export type MatcherFn = (pattern: Path, path: Path) => Match;
 
-export type MakeRegexFn = {
+export type MakeRegexpFn = {
   keys: Array<{ name: string | number }>;
   regexp: RegExp;
 };
@@ -29,5 +29,5 @@ export default function makeMatcher(
   makeRegexpFn?: (
     pattern: string,
     keys?: Array<{ name: string | number }>
-  ) => MakeRegexFn
+  ) => MakeRegexpFn
 ): MatcherFn;

--- a/types/matcher.d.ts
+++ b/types/matcher.d.ts
@@ -20,9 +20,14 @@ export type Match<T extends DefaultParams = DefaultParams> =
 
 export type MatcherFn = (pattern: Path, path: Path) => Match;
 
+export type MakeRegexFn = {
+  keys: Array<{ name: string | number }>;
+  regexp: RegExp;
+};
+
 export default function makeMatcher(
   makeRegexpFn?: (
     pattern: string,
     keys?: Array<{ name: string | number }>
-  ) => RegExp
+  ) => MakeRegexFn
 ): MatcherFn;


### PR DESCRIPTION
This PR fixes the return type of `makeRegexpFn` which is passed to `makeMatcher`. Let me know if it requires changes 👍🏼 

Fixes #180 