### PR TITLE
Replace map with forEach

### DIFF
--- a/use-location.js
+++ b/use-location.js
@@ -31,14 +31,14 @@ export default ({ base = "" } = {}) => {
       }
     };
 
-    events.map((e) => addEventListener(e, checkForUpdates));
+    events.forEach((e) => addEventListener(e, checkForUpdates));
 
     // it's possible that an update has occurred between render and the effect handler,
     // so we run additional check on mount to catch these updates. Based on:
     // https://gist.github.com/bvaughn/e25397f70e8c65b0ae0d7c90b731b189
     checkForUpdates();
 
-    return () => events.map((e) => removeEventListener(e, checkForUpdates));
+    return () => events.forEach((e) => removeEventListener(e, checkForUpdates));
   }, [base]);
 
   // the 2nd argument of the `useLocation` return value is a function


### PR DESCRIPTION
Since the result of `Array.map` in `use-location.js` isn't used it can be replaced, or is there a reason that I'm missing? Also in general `forEach` has better "performance" than `map`.

 Also I was going through the output bundle and I saw that the comments are still there, again am I missing something or aren't the comments stripped from the output bundles?