### PR TITLE
Chore/GitHub size workflow

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,12 @@
+name: Size
+on: [pull_request]
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    env:
+      CI_JOB_NUMBER: 1
+    steps:
+      - uses: actions/checkout@v1
+      - uses: andresz1/size-limit-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     }
   },
   "devDependencies": {
-    "@size-limit/preset-small-lib": "^4.9.2",
+    "@size-limit/preset-small-lib": "^4.10.1",
     "@testing-library/react": "^11.2.5",
     "@testing-library/react-hooks": "^5.0.3",
     "@types/react": "^17.0.1",
@@ -123,6 +123,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-test-renderer": "^17.0.1",
-    "rollup": "^2.38.5"
+    "rollup": "^2.38.5",
+    "size-limit": "^4.10.1"
   }
 }


### PR DESCRIPTION
### Add github size workflow

The size action will look at the `size-limit` entry in `package.json`, and report on every pull request, see [example](https://github.com/devrnt/react-use-wizard/pull/25#issuecomment-779427633) .