### PR TITLE
Ts infer params from path use route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules/
 # see https://github.com/sindresorhus/ama/issues/479#issuecomment-310661514
 /package-lock.json
 /yarn.lock
+/pnpm-lock.yaml
 
 # bundler
 dist/

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   ],
   "husky": {
     "hooks": {
-      "commit-msg": "yarn fix:p"
+      "commit-msg": "npm run fix:p"
     }
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,9 @@
     },
     "plugins": [
       "react-hooks"
+    ],
+    "ignorePatterns": [
+      "types/**"
     ]
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "react-test-renderer": "^17.0.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.38.5",
-    "size-limit": "^4.10.1"
+    "size-limit": "^4.10.1",
+    "typescript": "4.4.2"
   }
 }

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,13 +1,18 @@
 import { useState } from "react";
 
-export const memoryLocation = (path = "/") => () => useState(path);
+export const memoryLocation =
+  (path = "/") =>
+  () =>
+    useState(path);
 
-export const customHookWithReturn = (initialPath = "/") => () => {
-  const [path, updatePath] = useState(initialPath);
-  const navigate = (path) => {
-    updatePath(path);
-    return "foo";
+export const customHookWithReturn =
+  (initialPath = "/") =>
+  () => {
+    const [path, updatePath] = useState(initialPath);
+    const navigate = (path) => {
+      updatePath(path);
+      return "foo";
+    };
+
+    return [path, navigate];
   };
-
-  return [path, navigate];
-};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,25 +23,28 @@ import { DefaultParams, Params, Match, MatcherFn } from "./matcher";
 export * from "./matcher";
 export * from "./use-location";
 
-export type ExtractRouteOptionalParam<PathType extends Path> = PathType extends `${infer Param}?`
-  ? { [k in Param]: string }
-  : PathType extends `${infer Param}*`
-  ? { [k in Param]: string }
-  : PathType extends `${infer Param}+`
-  ? { [k in Param]: string }
-  : { [k in PathType]: string };
+export type ExtractRouteOptionalParam<PathType extends Path> =
+  PathType extends `${infer Param}?`
+    ? { [k in Param]: string }
+    : PathType extends `${infer Param}*`
+    ? { [k in Param]: string }
+    : PathType extends `${infer Param}+`
+    ? { [k in Param]: string }
+    : { [k in PathType]: string };
 
-export type ExtractRouteParams<PathType extends string> = string extends PathType
-  ? { [k in string]: string }
-  : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}/${infer Rest}`
-  ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
-    ? ExtractRouteOptionalParam<Param> & ExtractRouteParams<Rest>
-    : ExtractRouteOptionalParam<ParamWithOptionalRegExp> & ExtractRouteParams<Rest>
-  : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}`
-  ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
-    ? ExtractRouteOptionalParam<Param>
-    : ExtractRouteOptionalParam<ParamWithOptionalRegExp>
-  : {};
+export type ExtractRouteParams<PathType extends string> =
+  string extends PathType
+    ? { [k in string]: string }
+    : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}/${infer Rest}`
+    ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
+      ? ExtractRouteOptionalParam<Param> & ExtractRouteParams<Rest>
+      : ExtractRouteOptionalParam<ParamWithOptionalRegExp> &
+          ExtractRouteParams<Rest>
+    : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}`
+    ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
+      ? ExtractRouteOptionalParam<Param>
+      : ExtractRouteOptionalParam<ParamWithOptionalRegExp>
+    : {};
 
 /*
  * Components: <Route />
@@ -51,15 +54,27 @@ export interface RouteComponentProps<T extends DefaultParams = DefaultParams> {
   params: T;
 }
 
-export interface RouteProps<RoutePath extends Path = Path> {
-  children?: ((params: ExtractRouteParams<RoutePath>) => ReactNode) | ReactNode;
+export interface RouteProps<
+  T extends DefaultParams | undefined = undefined,
+  RoutePath extends Path = Path
+> {
+  children?:
+    | ((
+        params: T extends DefaultParams ? T : ExtractRouteParams<RoutePath>
+      ) => ReactNode)
+    | ReactNode;
   path?: RoutePath;
-  component?: ComponentType<RouteComponentProps<ExtractRouteParams<RoutePath>>>;
+  component?: ComponentType<
+    RouteComponentProps<
+      T extends DefaultParams ? T : ExtractRouteParams<RoutePath>
+    >
+  >;
 }
 
-export function Route<RoutePath extends Path>(
-  props: RouteProps<RoutePath>,
-): ReactElement | null;
+export function Route<
+  T extends DefaultParams | undefined = undefined,
+  RoutePath extends Path = Path
+>(props: RouteProps<T, RoutePath>): ReactElement | null;
 
 /*
  * Components: <Link /> & <Redirect />
@@ -77,11 +92,10 @@ export type LinkProps<H extends BaseLocationHook = LocationHook> = Omit<
 > &
   NavigationalProps<H>;
 
-export type RedirectProps<
-  H extends BaseLocationHook = LocationHook
-> = NavigationalProps<H> & {
-  children?: never;
-};
+export type RedirectProps<H extends BaseLocationHook = LocationHook> =
+  NavigationalProps<H> & {
+    children?: never;
+  };
 
 export function Redirect<H extends BaseLocationHook = LocationHook>(
   props: PropsWithChildren<RedirectProps<H>>,
@@ -124,9 +138,12 @@ export const Router: FunctionComponent<
 
 export function useRouter(): RouterProps;
 
-export function useRoute<T extends DefaultParams = DefaultParams>(
-  pattern: Path
-): Match<T>;
+export function useRoute<
+  T extends DefaultParams | undefined = undefined,
+  RoutePath extends Path = Path
+>(
+  pattern: RoutePath
+): Match<T extends DefaultParams ? T : ExtractRouteParams<RoutePath>>;
 
 export function useLocation<
   H extends BaseLocationHook = LocationHook

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,15 +23,24 @@ import { DefaultParams, Params, Match, MatcherFn } from "./matcher";
 export * from "./matcher";
 export * from "./use-location";
 
-type StripAsterisk<Str extends string> =
-  Str extends `${infer Start}*` ? Start : Str;
+export type ExtractRouteOptionalParam<PathType extends Path> = PathType extends `${infer Param}?`
+  ? { [k in Param]: string }
+  : PathType extends `${infer Param}*`
+  ? { [k in Param]: string }
+  : PathType extends `${infer Param}+`
+  ? { [k in Param]: string }
+  : { [k in PathType]: string };
 
-type ExtractRouteParams<T extends string> = string extends T
-  ? Record<string, string>
-  : T extends `${infer Start}:${infer Param}/${infer Rest}`
-  ? { [k in StripAsterisk<Param> | keyof ExtractRouteParams<Rest>]: string }
-  : T extends `${infer Start}:${infer Param}`
-  ? { [k in StripAsterisk<Param>]: string }
+export type ExtractRouteParams<PathType extends string> = string extends PathType
+  ? { [k in string]: string }
+  : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}/${infer Rest}`
+  ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
+    ? ExtractRouteOptionalParam<Param> & ExtractRouteParams<Rest>
+    : ExtractRouteOptionalParam<ParamWithOptionalRegExp> & ExtractRouteParams<Rest>
+  : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}`
+  ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
+    ? ExtractRouteOptionalParam<Param>
+    : ExtractRouteOptionalParam<ParamWithOptionalRegExp>
   : {};
 
 /*

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,6 +23,17 @@ import { DefaultParams, Params, Match, MatcherFn } from "./matcher";
 export * from "./matcher";
 export * from "./use-location";
 
+type StripAsterisk<Str extends string> =
+  Str extends `${infer Start}*` ? Start : Str;
+
+type ExtractRouteParams<T extends string> = string extends T
+  ? Record<string, string>
+  : T extends `${infer Start}:${infer Param}/${infer Rest}`
+  ? { [k in StripAsterisk<Param> | keyof ExtractRouteParams<Rest>]: string }
+  : T extends `${infer Start}:${infer Param}`
+  ? { [k in StripAsterisk<Param>]: string }
+  : {};
+
 /*
  * Components: <Route />
  */
@@ -31,14 +42,14 @@ export interface RouteComponentProps<T extends DefaultParams = DefaultParams> {
   params: T;
 }
 
-export interface RouteProps<T extends DefaultParams = DefaultParams> {
-  children?: ((params: Params<T>) => ReactNode) | ReactNode;
-  path?: Path;
-  component?: ComponentType<RouteComponentProps<T>>;
+export interface RouteProps<RoutePath extends Path = Path> {
+  children?: ((params: ExtractRouteParams<RoutePath>) => ReactNode) | ReactNode;
+  path?: RoutePath;
+  component?: ComponentType<RouteComponentProps<ExtractRouteParams<RoutePath>>>;
 }
 
-export function Route<T extends DefaultParams = DefaultParams>(
-  props: RouteProps<T>
+export function Route<RoutePath extends Path>(
+  props: RouteProps<RoutePath>,
 ): ReactElement | null;
 
 /*

--- a/types/matcher.d.ts
+++ b/types/matcher.d.ts
@@ -20,10 +20,10 @@ export type Match<T extends DefaultParams = DefaultParams> =
 
 export type MatcherFn = (pattern: Path, path: Path) => Match;
 
-export type PatternToRegexpResult = {
+export interface PatternToRegexpResult {
   keys: Array<{ name: string | number }>;
   regexp: RegExp;
-};
+}
 
 export default function makeMatcher(
   makeRegexpFn?: (pattern: string) => PatternToRegexpResult

--- a/types/type-specs.tsx
+++ b/types/type-specs.tsx
@@ -86,6 +86,11 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
   {({ first, second }) => `first: ${first}, second: ${second}`}
 </Route>;
 
+// for pathToRegexp matcher
+<Route path="/:user([a-z]i+)/profile/:tab/:first+/:second*">
+  {({ user, tab, first, second }) => `${user}, ${tab}, ${first}, ${second}`}
+</Route>;
+
 /*
  * Link and Redirect component type specs
  */

--- a/types/type-specs.tsx
+++ b/types/type-specs.tsx
@@ -48,11 +48,8 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
 <Route path={1337} />; // $ExpectError
 <Route />;
 
-// Supports various ways to declare children
 <Route path="/header" component={Header} />;
 <Route path="/profile/:id" component={Profile} />;
-<Route<{ id: string }> path="/profile/:id" component={Profile} />;
-<Route<{ name: string }> path="/profile/:name" component={Profile} />; // $ExpectError
 
 <Route path="/app">
   <div />
@@ -66,13 +63,28 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
   {(params: Params): React.ReactNode => `User id: ${params.id}`}
 </Route>;
 
-<Route<{ id: string }> path="/users/:id">{({ id }) => `User id: ${id}`}</Route>;
+<Route path="/users/:id">{({ id }) => `User id: ${id}`}</Route>;
 
-<Route<{ id: string }> path="/users/:id">
+<Route path="/users/:id">
   {({ age }) => `User age: ${age}`} // $ExpectError
 </Route>;
 
 <Route path="/app" match={true} />; // $ExpectError
+
+// inferred rest params
+<Route path="/path/:rest*">
+  {params => `Rest: ${params.rest}`}
+</Route>;
+
+// infer multiple params
+<Route path="/path/:first/:second/another/:third">
+  {({ first, second, third }) => `${first}, ${second}, ${third}`}
+</Route>;
+
+// infer only named params
+<Route path="/:first/:second">
+  {({ first, second }) => `first: ${first}, second: ${second}`}
+</Route>;
 
 /*
  * Link and Redirect component type specs

--- a/types/type-specs.tsx
+++ b/types/type-specs.tsx
@@ -69,12 +69,14 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
   {({ age }) => `User age: ${age}`} // $ExpectError
 </Route>;
 
+<Route path="/users/:id">
+  {({ age }: { age: string }) => `User age: ${age}`}
+</Route>;
+
 <Route path="/app" match={true} />; // $ExpectError
 
 // inferred rest params
-<Route path="/path/:rest*">
-  {params => `Rest: ${params.rest}`}
-</Route>;
+<Route path="/path/:rest*">{(params) => `Rest: ${params.rest}`}</Route>;
 
 // infer multiple params
 <Route path="/path/:first/:second/another/:third">
@@ -227,6 +229,15 @@ if (parameters) {
   parameters.age; // $ExpectError
 } else {
   parameters; // $ExpectType null
+}
+
+const [, inferedParams] = useRoute("/app/users/:id/:age");
+
+if (inferedParams) {
+  inferedParams.id; // $ExpectType string
+  inferedParams.age; // $ExpectType string
+} else {
+  inferedParams; // $ExpectType null
 }
 
 /*


### PR DESCRIPTION
This is based on the work done on #211 
The new changes are:
- Make path params type inference backward compatible
- Make path params type inference work with `useRoute`
Existing code shouldn't break with these changes.  