### PR TITLE
Make a more robust nested routing structure possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,11 +30,11 @@ const buildRouter = ({
   parent,
 } = {}) => ({
   hook,
-  relbase: base,
+  ownBase: base,
   parent,
   matcher: matcher ?? parent?.matcher ?? makeMatcher(),
   get base() {
-    return (this.parent?.base ?? "") + this.relbase;
+    return (this.parent?.base ?? "") + this.ownBase;
   },
 });
 
@@ -80,7 +80,7 @@ export const Router = (props) => {
   // Use the "latest ref" pattern.
   // https://epicreact.dev/the-latest-ref-pattern-in-react/
   useLayoutEffect(() => {
-    value.v.relbase = props.base || "";
+    value.v.ownBase = props.base || "";
     value.v.parent = props.parent;
   });
 


### PR DESCRIPTION
Here's my basic idea. Fixes #225 and fixes #257 while remaining fully backwards compatible. Alternative to #226. For the nested router use-case, it will now be possible to do:

```typescript
function NestedRouter(props) {
    return <Router {...props} parent={useRouter()}/>
}
```

If this PR gets some traction, I can update type definitions as needed.