### PR TITLE
Wrap Link with forwardRef

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import {
   createElement as h,
   Fragment,
   useState,
+  forwardRef,
 } from "./react-deps.js";
 
 /*
@@ -88,7 +89,7 @@ export const Route = ({ path, match, component, children }) => {
   return typeof children === "function" ? children(params) : children;
 };
 
-export const Link = (props) => {
+export const Link = forwardRef((props, ref) => {
   const navRef = useNavigate(props);
   const { base } = useRouter();
 
@@ -124,11 +125,12 @@ export const Link = (props) => {
     href: href[0] === "~" ? href.slice(1) : base + href,
     onClick: handleClick,
     to: null,
+    ref,
   };
   const jsx = isValidElement(children) ? children : h("a", props);
 
   return cloneElement(jsx, extraProps);
-};
+});
 
 const flattenChildren = (children) => {
   return Array.isArray(children)

--- a/preact/react-deps.js
+++ b/preact/react-deps.js
@@ -13,4 +13,8 @@ export {
   useContext,
   useCallback,
 } from "preact/hooks";
-export { forwardRef } from "preact/compat";
+
+// provide forwardRef stub for preact
+export function forwardRef(component) {
+  return component;
+}

--- a/preact/react-deps.js
+++ b/preact/react-deps.js
@@ -13,3 +13,4 @@ export {
   useContext,
   useCallback,
 } from "preact/hooks";
+export { forwardRef } from "preact/compat";

--- a/react-deps.js
+++ b/react-deps.js
@@ -10,4 +10,5 @@ export {
   cloneElement,
   createElement,
   Fragment,
+  forwardRef,
 } from "react";

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -3,6 +3,20 @@ import { render, cleanup, fireEvent } from "@testing-library/react";
 
 import { Router, Link } from "../index.js";
 
+const ParentComponent = (props) => {
+  const ref = React.createRef();
+
+  React.useEffect(() => {
+    ref.current.innerHTML = "Tested";
+  }, [ref])
+
+  return (
+    <Link href="/about" ref={ref}>
+      {props.children}
+    </Link>
+  );
+}
+
 afterEach(cleanup);
 
 it("renders a link with proper attributes", () => {
@@ -41,6 +55,31 @@ it("works for any other elements as well", () => {
   expect(link.className).toBe("link--wannabe");
   expect(link.textContent).toBe("Click Me");
 });
+
+it("passes ref to <a />", () => {
+  const { container } = render(
+    <ParentComponent>
+      Testing
+    </ParentComponent>
+  );
+  const link = container.firstChild;
+
+  expect(link.tagName).toBe("A");
+  expect(link.textContent).toBe("Tested");
+});
+
+it("passes ref to any other child element", () => {
+  const { container } = render(
+    <ParentComponent>
+      <div>Testing</div>
+    </ParentComponent>
+  );
+  const link = container.firstChild;
+
+  expect(link.tagName).toBe("DIV");
+  expect(link.textContent).toBe("Tested");
+});
+
 
 it("still creates a plain link when nothing is passed", () => {
   const { container } = render(<Link href="/about" />);

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -3,7 +3,7 @@ import { render, cleanup, fireEvent } from "@testing-library/react";
 
 import { Router, Link } from "../index.js";
 
-const ParentComponent = (props) => {
+const LinkWithForwardedRef = (props) => {
   const ref = React.createRef();
 
   React.useEffect(() => {
@@ -58,9 +58,9 @@ it("works for any other elements as well", () => {
 
 it("passes ref to <a />", () => {
   const { container } = render(
-    <ParentComponent>
+    <LinkWithForwardedRef>
       Testing
-    </ParentComponent>
+    </LinkWithForwardedRef>
   );
   const link = container.firstChild;
 
@@ -70,9 +70,9 @@ it("passes ref to <a />", () => {
 
 it("passes ref to any other child element", () => {
   const { container } = render(
-    <ParentComponent>
+    <LinkWithForwardedRef>
       <div>Testing</div>
-    </ParentComponent>
+    </LinkWithForwardedRef>
   );
   const link = container.firstChild;
 


### PR DESCRIPTION
Hi!
This relates to [#256](https://github.com/molefrog/wouter/issues/256)

Wrapping components with `forwardRef` is a common way component libraries expose underlying DOM to library users.
One particular example where it might be useful is passing `Link` down as a component to use in various navigation elements, e.g. MUI's `Buttons` and `Tabs` [See related doc section](https://mui.com/material-ui/guides/routing/#component-prop). Currently one'd write their own wrapper with same functionality as `Link`, but i thought it would be better to have wrapper out of the box. There aren't drawbacks i could think of, if you know about one, please, leave a comment.

Thanks.