### PR TITLE
TS: Parameter values are optional when can't be inferred 

### DIFF
--- a/preact/types/matcher.d.ts
+++ b/preact/types/matcher.d.ts
@@ -5,18 +5,14 @@
 import { Path } from "./use-location";
 
 export interface DefaultParams {
-  [paramName: string]: string;
+  readonly [paramName: string]: string | undefined;
 }
+
 export type Params<T extends DefaultParams = DefaultParams> = T;
 
-export type MatchWithParams<T extends DefaultParams = DefaultParams> = [
-  true,
-  Params<T>
-];
+export type MatchWithParams<T extends DefaultParams = DefaultParams> = [true, Params<T>];
 export type NoMatch = [false, null];
-export type Match<T extends DefaultParams = DefaultParams> =
-  | MatchWithParams<T>
-  | NoMatch;
+export type Match<T extends DefaultParams = DefaultParams> = MatchWithParams<T> | NoMatch;
 
 export type MatcherFn = (pattern: Path, path: Path) => Match;
 

--- a/preact/types/ts4.1/index.d.ts
+++ b/preact/types/ts4.1/index.d.ts
@@ -1,13 +1,7 @@
 // Minimum TypeScript Version: 4.1
 // tslint:disable:no-unnecessary-generics
 
-import {
-  JSX,
-  FunctionComponent,
-  ComponentType,
-  ComponentChildren,
-  VNode,
-} from "preact";
+import { JSX, FunctionComponent, ComponentType, ComponentChildren, VNode } from "preact";
 
 import {
   Path,
@@ -17,34 +11,31 @@ import {
   LocationHook,
 } from "../use-location";
 
-import { DefaultParams, Params, Match, MatcherFn } from "../matcher";
+import { DefaultParams, Match, MatcherFn } from "../matcher";
 
 // re-export types from these modules
 export * from "../matcher";
 export * from "../use-location";
 
-export type ExtractRouteOptionalParam<PathType extends Path> =
-  PathType extends `${infer Param}?`
-    ? { [k in Param]: string | undefined }
-    : PathType extends `${infer Param}*`
-    ? { [k in Param]: string | undefined }
-    : PathType extends `${infer Param}+`
-    ? { [k in Param]: string }
-    : { [k in PathType]: string };
+export type ExtractRouteOptionalParam<PathType extends Path> = PathType extends `${infer Param}?`
+  ? { readonly [k in Param]: string | undefined }
+  : PathType extends `${infer Param}*`
+  ? { readonly [k in Param]: string | undefined }
+  : PathType extends `${infer Param}+`
+  ? { readonly [k in Param]: string }
+  : { readonly [k in PathType]: string };
 
-export type ExtractRouteParams<PathType extends string> =
-  string extends PathType
-    ? { [k in string]: string }
-    : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}/${infer Rest}`
-    ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
-      ? ExtractRouteOptionalParam<Param> & ExtractRouteParams<Rest>
-      : ExtractRouteOptionalParam<ParamWithOptionalRegExp> &
-          ExtractRouteParams<Rest>
-    : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}`
-    ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
-      ? ExtractRouteOptionalParam<Param>
-      : ExtractRouteOptionalParam<ParamWithOptionalRegExp>
-    : {};
+export type ExtractRouteParams<PathType extends string> = string extends PathType
+  ? { readonly [k in string]: string | undefined }
+  : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}/${infer Rest}`
+  ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
+    ? ExtractRouteOptionalParam<Param> & ExtractRouteParams<Rest>
+    : ExtractRouteOptionalParam<ParamWithOptionalRegExp> & ExtractRouteParams<Rest>
+  : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}`
+  ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
+    ? ExtractRouteOptionalParam<Param>
+    : ExtractRouteOptionalParam<ParamWithOptionalRegExp>
+  : {};
 
 /*
  * Components: <Route />
@@ -59,15 +50,11 @@ export interface RouteProps<
   RoutePath extends Path = Path
 > {
   children?:
-    | ((
-        params: T extends DefaultParams ? T : ExtractRouteParams<RoutePath>
-      ) => ComponentChildren)
+    | ((params: T extends DefaultParams ? T : ExtractRouteParams<RoutePath>) => ComponentChildren)
     | ComponentChildren;
   path?: RoutePath;
   component?: ComponentType<
-    RouteComponentProps<
-      T extends DefaultParams ? T : ExtractRouteParams<RoutePath>
-    >
+    RouteComponentProps<T extends DefaultParams ? T : ExtractRouteParams<RoutePath>>
   >;
 }
 
@@ -92,10 +79,9 @@ export type LinkProps<H extends BaseLocationHook = LocationHook> = Omit<
 > &
   NavigationalProps<H>;
 
-export type RedirectProps<H extends BaseLocationHook = LocationHook> =
-  NavigationalProps<H> & {
-    children?: never;
-  };
+export type RedirectProps<H extends BaseLocationHook = LocationHook> = NavigationalProps<H> & {
+  children?: never;
+};
 
 export function Link<H extends BaseLocationHook = LocationHook>(
   props: LinkProps<H>
@@ -138,12 +124,8 @@ export function useRouter(): RouterProps;
 export function useRoute<
   T extends DefaultParams | undefined = undefined,
   RoutePath extends Path = Path
->(
-  pattern: RoutePath
-): Match<T extends DefaultParams ? T : ExtractRouteParams<RoutePath>>;
+>(pattern: RoutePath): Match<T extends DefaultParams ? T : ExtractRouteParams<RoutePath>>;
 
-export function useLocation<
-  H extends BaseLocationHook = LocationHook
->(): HookReturnValue<H>;
+export function useLocation<H extends BaseLocationHook = LocationHook>(): HookReturnValue<H>;
 
 // tslint:enable:no-unnecessary-generics

--- a/preact/types/ts4.1/index.d.ts
+++ b/preact/types/ts4.1/index.d.ts
@@ -26,7 +26,7 @@ export type ExtractRouteOptionalParam<PathType extends Path> = PathType extends 
   : { readonly [k in PathType]: string };
 
 export type ExtractRouteParams<PathType extends string> = string extends PathType
-  ? { readonly [k in string]: string | undefined }
+  ? DefaultParams
   : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}/${infer Rest}`
   ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
     ? ExtractRouteOptionalParam<Param> & ExtractRouteParams<Rest>

--- a/preact/types/ts4.1/type-specs.tsx
+++ b/preact/types/ts4.1/type-specs.tsx
@@ -60,19 +60,13 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
   This is a <b>mixed</b> content
 </Route>;
 
-<Route path="/users/:id">
-  {(params: Params): React.ReactNode => `User id: ${params.id}`}
-</Route>;
+<Route path="/users/:id">{(params: Params): React.ReactNode => `User id: ${params.id}`}</Route>;
 
 <Route path="/users/:id">{({ id }) => `User id: ${id}`}</Route>;
 
-<Route path="/users/:id">
-  {({ age }) => `User age: ${age}`} // $ExpectError
-</Route>;
+<Route path="/users/:id">{({ age }) => `User age: ${age}`}</Route>; // $ExpectError
 
-<Route path="/users/:id">
-  {({ age }: { age: string }) => `User age: ${age}`}
-</Route>;
+<Route path="/users/:id">{({ age }: { age: string }) => `User age: ${age}`}</Route>;
 
 <Route path="/app" match={true} />; // $ExpectError
 
@@ -85,9 +79,7 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
 </Route>;
 
 // infer only named params
-<Route path="/:first/:second">
-  {({ first, second }) => `first: ${first}, second: ${second}`}
-</Route>;
+<Route path="/:first/:second">{({ first, second }) => `first: ${first}, second: ${second}`}</Route>;
 
 // for pathToRegexp matcher
 <Route path="/:user([a-z]i+)/profile/:tab/:first+/:second*">
@@ -97,6 +89,14 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
     first; // $ExpectType string
     second; // $ExpectType string | undefined
     return `${user}, ${tab}, ${first}, ${second}`;
+  }}
+</Route>;
+
+<Route path={JSON.parse('"/home"')}>
+  {({ itemId }) => {
+    const fn = (a: string) => `noop ${a}`;
+    fn(itemId); // $ExpectError
+    return <div className={itemId} />;
   }}
 </Route>;
 
@@ -150,10 +150,7 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
 
 Redirect<UseNetworkLocation>({ href: "/home", delay: 1000 });
 // example custom hook
-type UseLocWithNoOptions = () => [
-  string,
-  (to: string, foo: number, bar: string) => void
-];
+type UseLocWithNoOptions = () => [string, (to: string, foo: number, bar: string) => void];
 Redirect<UseLocWithNoOptions>({ href: "/app" });
 
 <Redirect>something</Redirect>; // $ExpectError

--- a/types/matcher.d.ts
+++ b/types/matcher.d.ts
@@ -5,18 +5,14 @@
 import { Path } from "./use-location";
 
 export interface DefaultParams {
-  [paramName: string]: string;
+  readonly [paramName: string]: string | undefined;
 }
+
 export type Params<T extends DefaultParams = DefaultParams> = T;
 
-export type MatchWithParams<T extends DefaultParams = DefaultParams> = [
-  true,
-  Params<T>
-];
+export type MatchWithParams<T extends DefaultParams = DefaultParams> = [true, Params<T>];
 export type NoMatch = [false, null];
-export type Match<T extends DefaultParams = DefaultParams> =
-  | MatchWithParams<T>
-  | NoMatch;
+export type Match<T extends DefaultParams = DefaultParams> = MatchWithParams<T> | NoMatch;
 
 export type MatcherFn = (pattern: Path, path: Path) => Match;
 

--- a/types/ts4.1/index.d.ts
+++ b/types/ts4.1/index.d.ts
@@ -19,7 +19,7 @@ import {
   LocationHook,
 } from "../use-location";
 
-import { DefaultParams, Params, Match, MatcherFn } from "../matcher";
+import { DefaultParams, Match, MatcherFn } from "../matcher";
 import React = require("react");
 
 // re-export types from these modules
@@ -27,15 +27,15 @@ export * from "../matcher";
 export * from "../use-location";
 
 export type ExtractRouteOptionalParam<PathType extends Path> = PathType extends `${infer Param}?`
-  ? { [k in Param]: string | undefined }
+  ? { readonly [k in Param]: string | undefined }
   : PathType extends `${infer Param}*`
-  ? { [k in Param]: string | undefined }
+  ? { readonly [k in Param]: string | undefined }
   : PathType extends `${infer Param}+`
-  ? { [k in Param]: string }
-  : { [k in PathType]: string };
+  ? { readonly [k in Param]: string }
+  : { readonly [k in PathType]: string };
 
 export type ExtractRouteParams<PathType extends string> = string extends PathType
-  ? { [k in string]: string }
+  ? { readonly [k in string]: string | undefined }
   : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}/${infer Rest}`
   ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
     ? ExtractRouteOptionalParam<Param> & ExtractRouteParams<Rest>

--- a/types/ts4.1/index.d.ts
+++ b/types/ts4.1/index.d.ts
@@ -35,7 +35,7 @@ export type ExtractRouteOptionalParam<PathType extends Path> = PathType extends 
   : { readonly [k in PathType]: string };
 
 export type ExtractRouteParams<PathType extends string> = string extends PathType
-  ? { readonly [k in string]: string | undefined }
+  ? DefaultParams
   : PathType extends `${infer _Start}:${infer ParamWithOptionalRegExp}/${infer Rest}`
   ? ParamWithOptionalRegExp extends `${infer Param}(${infer _RegExp})`
     ? ExtractRouteOptionalParam<Param> & ExtractRouteParams<Rest>

--- a/types/ts4.1/type-specs.tsx
+++ b/types/ts4.1/type-specs.tsx
@@ -72,6 +72,14 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
 // inferred rest params
 <Route path="/path/:rest*">{(params) => `Rest: ${params.rest}`}</Route>;
 
+// type must be string | undefined
+<Route path="/path/:rest*">
+  {({ rest }) => {
+    const fn = (a: string) => "noop";
+    fn(rest); // $ExpectError
+  }}
+</Route>;
+
 // infer multiple params
 <Route path="/path/:first/:second/another/:third">
   {({ first, second, third }) => `${first}, ${second}, ${third}`}
@@ -88,6 +96,12 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
     first; // $ExpectType string
     second; // $ExpectType string | undefined
     return `${user}, ${tab}, ${first}, ${second}`;
+  }}
+</Route>;
+
+<Route path={JSON.parse('"/home"')}>
+  {({ itemId }) => {
+    return <div className={itemId} />;
   }}
 </Route>;
 

--- a/types/ts4.1/type-specs.tsx
+++ b/types/ts4.1/type-specs.tsx
@@ -101,6 +101,8 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
 
 <Route path={JSON.parse('"/home"')}>
   {({ itemId }) => {
+    const fn = (a: string) => `noop ${a}`;
+    fn(itemId); // $ExpectError
     return <div className={itemId} />;
   }}
 </Route>;


### PR DESCRIPTION
Partially addresses #229
Closes #214

- When route parameters can't be inferred at a compile time, they become optional now. Routes may contain optional segments (e.g. `/:rest*`) so some parameters could be `undefined`
- Parameter values are now `readonly`