### PR TITLE
React < 18: Fix incorrect `ReactNode` declaration

### DIFF
--- a/types/ts3.9.4/index.d.ts
+++ b/types/ts3.9.4/index.d.ts
@@ -6,7 +6,8 @@ import {
   PropsWithChildren,
   ComponentType,
   ReactElement,
-  ReactNode,
+  ReactChild,
+  ReactPortal,
 } from "react";
 
 import {
@@ -22,6 +23,11 @@ import { DefaultParams, Params, Match, MatcherFn } from "../matcher";
 // re-export types from these modules
 export * from "../matcher";
 export * from "../use-location";
+
+// React <18 only: fixes incorrect `ReactNode` declaration that had `{}` in the union.
+// This issue has been fixed in React 18 type declaration.
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210
+type ReactNode = ReactChild | ReactNode[] | ReactPortal | boolean | null | undefined;
 
 /*
  * Components: <Route />

--- a/types/ts3.9.4/index.d.ts
+++ b/types/ts3.9.4/index.d.ts
@@ -27,7 +27,7 @@ export * from "../use-location";
 // React <18 only: fixes incorrect `ReactNode` declaration that had `{}` in the union.
 // This issue has been fixed in React 18 type declaration.
 // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210
-type ReactNode = ReactChild | ReactNode[] | ReactPortal | boolean | null | undefined;
+type ReactNode = ReactChild | Iterable<ReactNode> | ReactPortal | boolean | null | undefined;
 
 /*
  * Components: <Route />

--- a/types/ts3.9.4/type-specs.tsx
+++ b/types/ts3.9.4/type-specs.tsx
@@ -62,7 +62,7 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
   This is a <b>mixed</b> content
 </Route>;
 
-<Route path="/users/:id">{(params: Params): React.ReactNode => `User id: ${params.id}`}</Route>;
+<Route path="/users/:id">{(params: Params) => `User id: ${params.id}`}</Route>;
 
 <Route<{ id: string }> path="/users/:id">{({ id }) => `User id: ${id}`}</Route>;
 

--- a/types/ts4.1/index.d.ts
+++ b/types/ts4.1/index.d.ts
@@ -30,7 +30,7 @@ export * from "../use-location";
 // React <18 only: fixes incorrect `ReactNode` declaration that had `{}` in the union.
 // This issue has been fixed in React 18 type declaration.
 // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210
-type ReactNode = ReactChild | ReactNode[] | ReactPortal | boolean | null | undefined;
+type ReactNode = ReactChild | Iterable<ReactNode> | ReactPortal | boolean | null | undefined;
 
 export type ExtractRouteOptionalParam<PathType extends Path> = PathType extends `${infer Param}?`
   ? { readonly [k in Param]: string | undefined }

--- a/types/ts4.1/index.d.ts
+++ b/types/ts4.1/index.d.ts
@@ -8,7 +8,8 @@ import {
   PropsWithChildren,
   ComponentType,
   ReactElement,
-  ReactNode,
+  ReactChild,
+  ReactPortal,
 } from "react";
 
 import {
@@ -25,6 +26,11 @@ import React = require("react");
 // re-export types from these modules
 export * from "../matcher";
 export * from "../use-location";
+
+// React <18 only: fixes incorrect `ReactNode` declaration that had `{}` in the union.
+// This issue has been fixed in React 18 type declaration.
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210
+type ReactNode = ReactChild | ReactNode[] | ReactPortal | boolean | null | undefined;
 
 export type ExtractRouteOptionalParam<PathType extends Path> = PathType extends `${infer Param}?`
   ? { readonly [k in Param]: string | undefined }

--- a/types/ts4.1/type-specs.tsx
+++ b/types/ts4.1/type-specs.tsx
@@ -59,7 +59,7 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
   This is a <b>mixed</b> content
 </Route>;
 
-<Route path="/users/:id">{(params: Params): React.ReactNode => `User id: ${params.id}`}</Route>;
+<Route path="/users/:id">{(params: Params) => `User id: ${params.id}`}</Route>;
 
 <Route path="/users/:id">{({ id }) => `User id: ${id}`}</Route>;
 
@@ -77,6 +77,8 @@ const invalidParamsWithGeneric: Params<{ id: number }> = { id: 13 }; // $ExpectE
   {({ rest }) => {
     const fn = (a: string) => "noop";
     fn(rest); // $ExpectError
+
+    return <></>;
   }}
 </Route>;
 


### PR DESCRIPTION
Closes #229

This PR declares more strict `ReactNode` that excludes `{}`. Only relevant to React.
It also fixes some incorrect test cases.