### PR TITLE
Support for `parent` prop in Router

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ export const Router = ({
     router.base = proto.base + base;
 
     // parent router reference, `undefined` when router is top-level
-    router.parent = proto === defaultRouter ? proto : undefined;
+    router.parent = proto === defaultRouter ? undefined : proto;
 
     return router;
   };

--- a/index.js
+++ b/index.js
@@ -61,7 +61,13 @@ const useNavigate = (options) => {
  * Part 2, Low Carb Router API: Router, Route, Link, Switch
  */
 
-export const Router = ({ hook, matcher, base = "", nested = false, children }) => {
+export const Router = ({
+  hook,
+  matcher,
+  base = "",
+  nested = false,
+  children,
+}) => {
   const parent = useRouter();
 
   // nested `<Router />` has the scope of its closest parent router (base path is prepended)
@@ -115,7 +121,13 @@ export const Link = forwardRef((props, ref) => {
     (event) => {
       // ignores the navigation when clicked using right mouse button or
       // by holding a special modifier key: ctrl, command, win, alt, shift
-      if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey || event.button !== 0)
+      if (
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey ||
+        event.shiftKey ||
+        event.button !== 0
+      )
         return;
 
       onClick && onClick(event);
@@ -146,7 +158,9 @@ const flattenChildren = (children) => {
   return Array.isArray(children)
     ? [].concat(
         ...children.map((c) =>
-          c && c.type === Fragment ? flattenChildren(c.props.children) : flattenChildren(c)
+          c && c.type === Fragment
+            ? flattenChildren(c.props.children)
+            : flattenChildren(c)
         )
       )
     : [children];

--- a/index.js
+++ b/index.js
@@ -61,7 +61,13 @@ const useNavigate = (options) => {
  * Part 2, Low Carb Router API: Router, Route, Link, Switch
  */
 
-export const Router = ({ hook, matcher, base = "", nested = false, children }) => {
+export const Router = ({
+  hook,
+  matcher,
+  base = "",
+  nested = false,
+  children,
+}) => {
   const parent = useRouter();
 
   // nested `<Router />` has the scope of its closest parent router (base path is prepended)
@@ -110,7 +116,13 @@ export const Link = forwardRef((props, ref) => {
     (event) => {
       // ignores the navigation when clicked using right mouse button or
       // by holding a special modifier key: ctrl, command, win, alt, shift
-      if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey || event.button !== 0)
+      if (
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey ||
+        event.shiftKey ||
+        event.button !== 0
+      )
         return;
 
       onClick && onClick(event);
@@ -141,7 +153,9 @@ const flattenChildren = (children) => {
   return Array.isArray(children)
     ? [].concat(
         ...children.map((c) =>
-          c && c.type === Fragment ? flattenChildren(c.props.children) : flattenChildren(c)
+          c && c.type === Fragment
+            ? flattenChildren(c.props.children)
+            : flattenChildren(c)
         )
       )
     : [children];

--- a/index.js
+++ b/index.js
@@ -61,27 +61,15 @@ const useNavigate = (options) => {
  * Part 2, Low Carb Router API: Router, Route, Link, Switch
  */
 
-export const Router = ({
-  hook,
-  matcher,
-  base = "",
-  nested = false,
-  children,
-}) => {
-  const parent = useRouter();
-
-  // nested `<Router />` has the scope of its closest parent router (base path is prepended)
-  // Routers are not nested by default, but this might change in future versions
-  const proto = nested ? parent : defaultRouter;
-
+export const Router = ({ hook, matcher, base = "", parent, children }) => {
   // updates the current router with the props passed down to the component
-  const updateRouter = (router) => {
+  const updateRouter = (router, proto = parent || defaultRouter) => {
     router.hook = hook || proto.hook;
     router.matcher = matcher || proto.matcher;
     router.base = proto.base + base;
 
-    // parent router reference, `undefined` when router is top-level
-    router.parent = proto === defaultRouter ? undefined : proto;
+    // store reference to parent router
+    router.parent = parent;
 
     return router;
   };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ import matcherWithCache from "./matcher.js";
 
 import {
   useRef,
-  useLayoutEffect,
   useContext,
   useCallback,
   createContext,
@@ -13,6 +12,7 @@ import {
   Fragment,
   useState,
   forwardRef,
+  useIsomorphicLayoutEffect,
 } from "./react-deps.js";
 
 /*
@@ -73,12 +73,16 @@ export const Router = ({ hook, matcher, base = "", nested = false, children }) =
     router.hook = hook || proto.hook;
     router.matcher = matcher || proto.matcher;
     router.base = proto.base + base;
+
+    return router;
   };
 
   // we use `useState` here, but it only catches the first render and never changes.
   // https://reactjs.org/docs/hooks-faq.html#how-to-create-expensive-objects-lazily
-  const [value] = useState(() => ({})); // create the object once...
-  updateRouter(value); // then update it on each render
+  const [value] = useState(() => updateRouter({})); // create the object once...
+  useIsomorphicLayoutEffect(() => {
+    updateRouter(value);
+  }); // ...then update it on each render
 
   return h(RouterCtx.Provider, {
     value,
@@ -175,7 +179,7 @@ export const Redirect = (props) => {
   const navRef = useNavigate(props);
 
   // empty array means running the effect once, navRef is a ref so it never changes
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     navRef.current();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/index.js
+++ b/index.js
@@ -80,6 +80,9 @@ export const Router = ({
     router.matcher = matcher || proto.matcher;
     router.base = proto.base + base;
 
+    // parent router reference, `undefined` when router is top-level
+    router.parent = proto === defaultRouter ? proto : undefined;
+
     return router;
   };
 

--- a/preact/react-deps.js
+++ b/preact/react-deps.js
@@ -1,14 +1,9 @@
-export {
-  isValidElement,
-  createContext,
-  cloneElement,
-  createElement,
-  Fragment,
-} from "preact";
+export { isValidElement, createContext, cloneElement, createElement, Fragment } from "preact";
 export {
   useRef,
   useEffect,
   useLayoutEffect,
+  useLayoutEffect as useIsomorphicLayoutEffect,
   useState,
   useContext,
   useCallback,

--- a/preact/react-deps.js
+++ b/preact/react-deps.js
@@ -1,4 +1,10 @@
-export { isValidElement, createContext, cloneElement, createElement, Fragment } from "preact";
+export {
+  isValidElement,
+  createContext,
+  cloneElement,
+  createElement,
+  Fragment,
+} from "preact";
 export {
   useRef,
   useEffect,

--- a/preact/react-deps.js
+++ b/preact/react-deps.js
@@ -8,7 +8,6 @@ export {
 export {
   useRef,
   useEffect,
-  useLayoutEffect,
   useLayoutEffect as useIsomorphicLayoutEffect,
   useState,
   useContext,

--- a/react-deps.js
+++ b/react-deps.js
@@ -3,7 +3,6 @@ import { useEffect, useLayoutEffect } from "react";
 export {
   useRef,
   useEffect,
-  useLayoutEffect,
   useState,
   useContext,
   useCallback,

--- a/react-deps.js
+++ b/react-deps.js
@@ -27,4 +27,6 @@ export const canUseDOM = !!(
   typeof window.document.createElement !== "undefined"
 );
 
-export const useIsomorphicLayoutEffect = canUseDOM ? useLayoutEffect : useEffect;
+export const useIsomorphicLayoutEffect = canUseDOM
+  ? useLayoutEffect
+  : useEffect;

--- a/react-deps.js
+++ b/react-deps.js
@@ -1,3 +1,5 @@
+import { useEffect, useLayoutEffect } from "react";
+
 export {
   useRef,
   useEffect,
@@ -12,3 +14,17 @@ export {
   Fragment,
   forwardRef,
 } from "react";
+
+// React currently throws a warning when using useLayoutEffect on the server.
+// To get around it, we can conditionally useEffect on the server (no-op) and
+// useLayoutEffect in the browser.
+
+// See Redux's source code for reference:
+// https://github.com/reduxjs/react-redux/blob/master/src/utils/useIsomorphicLayoutEffect.ts
+export const canUseDOM = !!(
+  typeof window !== "undefined" &&
+  typeof window.document !== "undefined" &&
+  typeof window.document.createElement !== "undefined"
+);
+
+export const useIsomorphicLayoutEffect = canUseDOM ? useLayoutEffect : useEffect;

--- a/test/ssr.test.js
+++ b/test/ssr.test.js
@@ -5,7 +5,7 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { Route, Router, useRoute, Link } from "../index";
+import { Route, Router, useRoute, Link, Redirect } from "../index";
 import staticLocationHook from "../static-location.js";
 
 describe("server-side rendering", () => {
@@ -50,5 +50,20 @@ describe("server-side rendering", () => {
 
     const rendered = renderToStaticMarkup(<App />);
     expect(rendered).toBe(`<a href="/users/1" title="Profile">Mark</a>`);
+  });
+
+  it("renders redirects however they have effect only on a client-side", () => {
+    const App = () => (
+      <Router hook={staticLocationHook("/")}>
+        <Route path="/">
+          <Redirect to="/foo" />
+        </Route>
+
+        <Route path="/foo">You won't see that in SSR page</Route>
+      </Router>
+    );
+
+    const rendered = renderToStaticMarkup(<App />);
+    expect(rendered).toBe("");
   });
 });

--- a/test/use-router.test.js
+++ b/test/use-router.test.js
@@ -54,7 +54,9 @@ it("shares one router instance between components", () => {
     </>
   );
 
-  const uniqRouters = [...new Set(root.findAllByType("div").map((x) => x.props.router))];
+  const uniqRouters = [
+    ...new Set(root.findAllByType("div").map((x) => x.props.router)),
+  ];
   expect(uniqRouters.length).toBe(1);
 });
 

--- a/test/use-router.test.js
+++ b/test/use-router.test.js
@@ -54,8 +54,34 @@ it("shares one router instance between components", () => {
     </>
   );
 
-  const uniqRouters = [
-    ...new Set(root.findAllByType("div").map((x) => x.props.router)),
-  ];
+  const uniqRouters = [...new Set(root.findAllByType("div").map((x) => x.props.router))];
   expect(uniqRouters.length).toBe(1);
+});
+
+it("inherits base path from the parent router when `nested` flag is provided", () => {
+  const { result } = renderHook(() => useRouter(), {
+    wrapper: (props) => (
+      <Router base="/app">
+        <Router base="/users" nested>
+          {props.children}
+        </Router>
+      </Router>
+    ),
+  });
+
+  const router = result.current;
+  expect(router.base).toBe("/app/users");
+});
+
+it("does not inherit base path by default", () => {
+  const { result } = renderHook(() => useRouter(), {
+    wrapper: (props) => (
+      <Router base="/app">
+        <Router base="/users">{props.children}</Router>
+      </Router>
+    ),
+  });
+
+  const router = result.current;
+  expect(router.base).toBe("/users");
 });

--- a/test/use-router.test.js
+++ b/test/use-router.test.js
@@ -63,7 +63,7 @@ it("shares one router instance between components", () => {
 it("inherits base path from the parent router when parent router is provided", () => {
   const NestedRouter = (props) => {
     const parent = useRouter();
-    return <Router {...props} parent={parent} />;
+    return <Router {...props} parent={props.nested ? parent : undefined} />;
   };
 
   const { result } = renderHook(() => useRouter(), {

--- a/test/use-router.test.js
+++ b/test/use-router.test.js
@@ -60,13 +60,18 @@ it("shares one router instance between components", () => {
   expect(uniqRouters.length).toBe(1);
 });
 
-it("inherits base path from the parent router when `nested` flag is provided", () => {
+it("inherits base path from the parent router when parent router is provided", () => {
+  const NestedRouter = (props) => {
+    const parent = useRouter();
+    return <Router {...props} parent={parent} />;
+  };
+
   const { result } = renderHook(() => useRouter(), {
     wrapper: (props) => (
       <Router base="/app">
-        <Router base="/users" nested>
+        <NestedRouter base="/users" nested>
           {props.children}
-        </Router>
+        </NestedRouter>
       </Router>
     ),
   });

--- a/test/use-router.test.js
+++ b/test/use-router.test.js
@@ -72,6 +72,7 @@ it("inherits base path from the parent router when `nested` flag is provided", (
   });
 
   const router = result.current;
+  expect(router.parent.base).toBe("/app");
   expect(router.base).toBe("/app/users");
 });
 
@@ -86,4 +87,5 @@ it("does not inherit base path by default", () => {
 
   const router = result.current;
   expect(router.base).toBe("/users");
+  expect(router.parent).toBe(undefined);
 });


### PR DESCRIPTION
It's an alternative solution to #231.
Notable differences:
1. Because `<Router />` is immutable (it only gets created once and doesn't react on props change) we can simply make a copy of the parent router, it does not have to be dynamic.
2. Changed the API, there is no need now to write `parent={useRouter()}` which IMO could be not obvious for some users. Instead, by adding a `nested` prop, we the the router to inherit the base path. I even think that we can enable this by default in future releases.
3. Simplified the context it passed an object instead of a reference. This might sound like a performance downgrade, but in reality because Router is immutable it never changes between renders. Hence, context update won't be triggered.