### PR TITLE
Fixes for wouter-preact

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,7 @@
   "module": "index.js",
   "types": "types/ts3.9.4/index.d.ts",
   "typesVersions": {
-    ">=4.1": {
-      "types/ts3.9.4/index.d.ts": [
-        "types/ts4.1/index.d.ts"
-      ],
+    "*": {
       "use-location": [
         "types/use-location.d.ts"
       ],
@@ -53,6 +50,11 @@
       ],
       "static-location": [
         "types/static-location.d.ts"
+      ]
+    },
+    ">=4.1": {
+      "types/ts3.9.4/index.d.ts": [
+        "types/ts4.1/index.d.ts"
       ]
     }
   },

--- a/preact/package.json
+++ b/preact/package.json
@@ -32,10 +32,21 @@
   "module": "index.js",
   "types": "types/ts3.9.4/index.d.ts",
   "typesVersions": {
+    "*": {
+      "use-location": [
+        "types/use-location.d.ts"
+      ],
+      "matcher": [
+        "types/matcher.d.ts"
+      ],
+      "static-location": [
+        "types/static-location.d.ts"
+      ]
+    },
     ">=4.1": {
       "types/ts3.9.4/index.d.ts": [
         "types/ts4.1/index.d.ts"
-      ]
+      ]      
     }
   },
   "author": "Alexey Taktarov <molefrog@gmail.com>",

--- a/static-location.js
+++ b/static-location.js
@@ -1,4 +1,4 @@
-import { relativePath } from "./use-location";
+import { relativePath } from "./use-location.js";
 
 // Generates static `useLocation` hook. The hook always
 // responds with initial path provided.


### PR DESCRIPTION
This PR is a follow-up to #249 to fix `wouter-preact` in native ESM environments. It does ... 

1. Add module specifiers from the exports map to typesVersions in `wouter-preact`, too.
2. Set the version to `"*"` for these exports, so it works in TS < 4.1, too.
3. Add missing `.js` extension, so the import can be resolved in native ESM envs.