### PR TITLE
Fix use-sync-external-store import for Webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "lint-types-preact": "npm run preact && npm run types-preact && dtslint preact/types/ts4.1 --localTs ./node_modules/typescript/lib && dtslint preact/types/ts3.9.4 --localTs ./node_modules/typescript-3.9.4/lib",
     "preact": "copyfiles -f {index,matcher,use-location,static-location}.js preact/",
     "types-preact": "copyfiles -f types/{matcher,use-location,static-location}.d.ts preact/types",
-    "bundle": "rollup -e react,preact,use-sync-external-store/shim -f cjs --exports named --preserveModules -d ${DIR}cjs ${DIR}*.js && rollup -f cjs --exports auto -d ${DIR}cjs ${DIR}static-location.js && echo '{\"type\": \"commonjs\"}' > ${DIR}cjs/package.json",
+    "bundle": "rollup -e react,preact,use-sync-external-store/shim/index.js,use-sync-external-store/shim/index.native.js -f cjs --exports named --preserveModules -d ${DIR}cjs ${DIR}*.js && rollup -f cjs --exports auto -d ${DIR}cjs ${DIR}static-location.js && echo '{\"type\": \"commonjs\"}' > ${DIR}cjs/package.json",
     "prepublishOnly": "npm run clean && npm run preact && npm run types-preact && npm run bundle && DIR=./preact/ npm run bundle"
   },
   "author": "Alexey Taktarov <molefrog@gmail.com>",
@@ -141,7 +141,7 @@
       "\\.js$": "jest-esm-jsx-transform"
     },
     "collectCoverageFrom": [
-      "*.js"
+      "*.js", "!use-sync-external-store*.js"
     ]
   },
   "devDependencies": {

--- a/react-deps.js
+++ b/react-deps.js
@@ -16,7 +16,12 @@ export {
   forwardRef,
 } from "react";
 
-export { useSyncExternalStore } from "use-sync-external-store/shim";
+// To resolve webpack 5 errors, while not presenting problems for native,
+// we copy the approaches from https://github.com/TanStack/query/pull/3561
+// and https://github.com/TanStack/query/pull/3601
+// ~ Show this aging PR some love to remove the need for this hack:
+//   https://github.com/facebook/react/pull/25231 ~
+export { useSyncExternalStore } from "./use-sync-external-store";
 
 // Copied from:
 // https://github.com/facebook/react/blob/main/packages/shared/ExecutionEnvironment.js

--- a/use-sync-external-store.js
+++ b/use-sync-external-store.js
@@ -1,0 +1,1 @@
+export { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'

--- a/use-sync-external-store.js
+++ b/use-sync-external-store.js
@@ -1,1 +1,1 @@
-export { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+export { useSyncExternalStore } from "use-sync-external-store/shim/index.js";

--- a/use-sync-external-store.native.js
+++ b/use-sync-external-store.native.js
@@ -1,0 +1,1 @@
+export { useSyncExternalStore } from 'use-sync-external-store/shim/index.native.js'

--- a/use-sync-external-store.native.js
+++ b/use-sync-external-store.native.js
@@ -1,1 +1,1 @@
-export { useSyncExternalStore } from 'use-sync-external-store/shim/index.native.js'
+export { useSyncExternalStore } from "use-sync-external-store/shim/index.native.js";


### PR DESCRIPTION
Fixes #275 
There is an open facebook PR that should fix this as well whenever it EVENTUALLY gets merged: https://github.com/facebook/react/pull/25231

But in the meantime, React Query seems to have had luck with this hack.

(See https://github.com/TanStack/query/pull/3561 and https://github.com/TanStack/query/pull/3601)