### PR TITLE
Support new moduleResolution of TypeScript >= 4.7.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,18 +21,22 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./types/ts4.1/index.d.ts",
       "require": "./cjs/index.js",
       "default": "./index.js"
     },
     "./use-location": {
+      "types": "./types/use-location.d.ts",
       "require": "./cjs/use-location.js",
       "default": "./use-location.js"
     },
     "./matcher": {
+      "types": "./types/matcher.d.ts",
       "require": "./cjs/matcher.js",
       "default": "./matcher.js"
     },
     "./static-location": {
+      "types": "./types/static-location.d.ts",
       "require": "./cjs/static-location.js",
       "default": "./static-location.js"
     }


### PR DESCRIPTION
TypeScript 4.7 adds new values for "moduleResolution": "node16" and "nodenext", which enable ESM features.

Since `exports` now takes precedence in package.json and wouter's type files are not located next to their corresponding .js-files, it is necessary to declare `types` for each entry under `exports`.