### PR TITLE
update packages sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 <img src="assets/wouter.svg" align="right" width="250" alt="by Katya Simacheva" />
 
-- Zero dependency, only **1.36 KB** gzipped vs 11KB
+- Zero dependency, only **4.4 KB** minified vs 65.8KB
   [React Router](https://github.com/ReactTraining/react-router).
 - Supports both **React** and **[Preact](https://preactjs.com/)**! Read
   _["Preact support" section](#preact-support)_ for more details.


### PR DESCRIPTION
![2023-05-20_08-32_1](https://github.com/molefrog/wouter/assets/6022888/93fbe062-4a5f-46a1-b11a-d47f933440d4)

![2023-05-20_08-32](https://github.com/molefrog/wouter/assets/6022888/08e17e5a-4c0c-4675-ab40-a8287c92f73b)

I think minified versions is better for size comparison. Because wouter becomes only 2x smaller after gzip, but react-router - 3x smaller.

And i think minified size matters even more than gzipped, because scripts loads once, then cached. But they parsed and 
evaluated on every load. Therefore 65 Kb slow down script execution much more than 4.4 Kb