### PR TITLE
feat: add navigation state support to routes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ from the `useState` hook:
 import { useLocation } from "wouter";
 
 const CurrentLocation = () => {
-  const [location, setLocation] = useLocation();
+  const [location, setLocation, state] = useLocation();
 
   return (
     <div>
@@ -198,6 +198,7 @@ const [location, navigate] = useLocation();
 
 navigate("/jobs"); // `pushState` is used
 navigate("/home", { replace: true }); // `replaceState` is used
+navigate("/user", { state: { msg: "hello" } }); // pass state to route
 ```
 
 #### Customizing the location hook
@@ -300,6 +301,9 @@ import { Link } from "wouter"
 
 // lazy form: `a` element is constructed around children
 <Link href="/foo" className="active">Hello!</Link>
+
+// pass state to route
+<Link href="/foo" state={{ msg: "hello" }} className="active">Hello!</Link>
 
 // when using your own component or jsx the `href` prop
 // will be passed down to an element

--- a/use-location.js
+++ b/use-location.js
@@ -40,8 +40,8 @@ export const usePathname = ({ ssrPath } = {}) =>
     ssrPath ? () => ssrPath : currentPathname
   );
 
-export const navigate = (to, { replace = false } = {}) =>
-  history[replace ? eventReplaceState : eventPushState](null, "", to);
+export const navigate = (to, { replace = false, state = null } = {}) =>
+  history[replace ? eventReplaceState : eventPushState](state, "", to);
 
 // the 2nd argument of the `useLocation` return value is a function
 // that allows to perform a navigation.
@@ -52,6 +52,7 @@ export const navigate = (to, { replace = false } = {}) =>
 const useLocation = (opts = {}) => [
   relativePath(opts.base, usePathname(opts)),
   useEvent((to, navOpts) => navigate(absolutePath(to, opts.base), navOpts)),
+  history.state,
 ];
 
 export default useLocation;

--- a/use-location.js
+++ b/use-location.js
@@ -26,6 +26,14 @@ const subscribeToLocationUpdates = (callback) => {
   };
 };
 
+const getHistoryState = () => {
+  try {
+    return history.state;
+  } catch (error) {
+    return null;
+  }
+};
+
 export const useLocationProperty = (fn, ssrFn) =>
   useSyncExternalStore(subscribeToLocationUpdates, fn, ssrFn);
 
@@ -52,7 +60,7 @@ export const navigate = (to, { replace = false, state = null } = {}) =>
 const useLocation = (opts = {}) => [
   relativePath(opts.base, usePathname(opts)),
   useEvent((to, navOpts) => navigate(absolutePath(to, opts.base), navOpts)),
-  history.state,
+  getHistoryState(),
 ];
 
 export default useLocation;


### PR DESCRIPTION
in short: this PR is related to [#316](https://github.com/molefrog/wouter/issues/316)
### Details
Currently in wouter navigation state feature is not available, 
that's why we can't pass state to routes like **react-router-dom** . so I have added this feature. 
### Examples:
```js
import { Link , useLocation } from "wouter";

// pass state using Link component
<Link href="/foo" state={{ msg: "hello" }} className="active">Hello!</Link>

// get & set state using useLocation hooks
const [location, setLocation, state] = useLocation();

setLocation("/user", { state: { msg: "hello" } }); 
```
