### PR TITLE
chore(v3): fix ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@types/react": "^18.2.0",
     "@types/react-test-renderer": "^18.0.0",
     "@vitejs/plugin-react": "^4.0.4",
-    "@vitest/coverage-c8": "^0.33.0",
+    "@vitest/coverage-v8": "^0.34.3",
     "concurrently": "^8.2.1",
     "copyfiles": "^2.4.1",
     "dtslint": "^3.4.2",
@@ -129,3 +129,4 @@
     "vitest": "^0.34.3"
   }
 }
+


### PR DESCRIPTION
replace outdated `coverage-c8` with the new `coverage-v8` package