### PR TITLE
don't use global location, because it doesn't work on cloudflare workers

### DIFF
--- a/paths.js
+++ b/paths.js
@@ -3,13 +3,12 @@
  * If base isn't part of the path provided returns absolute path e.g. `~/app`
  */
 export const relativePath = (base = "", path = "") => {
-  if (!path && typeof location!="undefined")
-      path=location.pathname;
+  if (!path && typeof location != "undefined") path = location.pathname;
 
   return !path.toLowerCase().indexOf(base.toLowerCase())
     ? path.slice(base.length) || "/"
     : "~" + path;
-}
+};
 
 export const absolutePath = (to, base = "") =>
   to[0] === "~" ? to.slice(1) : base + to;

--- a/paths.js
+++ b/paths.js
@@ -2,10 +2,14 @@
  * Transforms `path` into its relative `base` version
  * If base isn't part of the path provided returns absolute path e.g. `~/app`
  */
-export const relativePath = (base = "", path = location.pathname) =>
-  !path.toLowerCase().indexOf(base.toLowerCase())
+export const relativePath = (base = "", path = "") => {
+  if (!path && typeof location!="undefined")
+      path=location.pathname;
+
+  return !path.toLowerCase().indexOf(base.toLowerCase())
     ? path.slice(base.length) || "/"
     : "~" + path;
+}
 
 export const absolutePath = (to, base = "") =>
   to[0] === "~" ? to.slice(1) : base + to;

--- a/use-location.js
+++ b/use-location.js
@@ -30,26 +30,23 @@ export const useLocationProperty = (fn, ssrFn) =>
   useSyncExternalStore(subscribeToLocationUpdates, fn, ssrFn);
 
 const currentSearch = () => {
-  if (typeof location!="undefined")
-    location.search;
-}
+  if (typeof location != "undefined") location.search;
+};
 
 export const useSearch = () => useLocationProperty(currentSearch);
 
 const currentPathname = () => {
-  if (typeof location!="undefined")
-    return location.pathname;
-}
+  if (typeof location != "undefined") return location.pathname;
+};
 
 export const usePathname = ({ ssrPath } = {}) => {
-  if (ssrPath)
-    return ssrPath;
+  if (ssrPath) return ssrPath;
 
   return useLocationProperty(
     currentPathname,
     ssrPath ? () => ssrPath : currentPathname
   );
-}
+};
 
 export const navigate = (to, { replace = false } = {}) =>
   history[replace ? eventReplaceState : eventPushState](null, "", to);

--- a/use-location.js
+++ b/use-location.js
@@ -29,16 +29,27 @@ const subscribeToLocationUpdates = (callback) => {
 export const useLocationProperty = (fn, ssrFn) =>
   useSyncExternalStore(subscribeToLocationUpdates, fn, ssrFn);
 
-const currentSearch = () => location.search;
+const currentSearch = () => {
+  if (typeof location!="undefined")
+    location.search;
+}
+
 export const useSearch = () => useLocationProperty(currentSearch);
 
-const currentPathname = () => location.pathname;
+const currentPathname = () => {
+  if (typeof location!="undefined")
+    return location.pathname;
+}
 
-export const usePathname = ({ ssrPath } = {}) =>
-  useLocationProperty(
+export const usePathname = ({ ssrPath } = {}) => {
+  if (ssrPath)
+    return ssrPath;
+
+  return useLocationProperty(
     currentPathname,
     ssrPath ? () => ssrPath : currentPathname
   );
+}
 
 export const navigate = (to, { replace = false } = {}) =>
   history[replace ? eventReplaceState : eventPushState](null, "", to);


### PR DESCRIPTION
In a couple of places there are references to `location`, which on a browser reads the location from `window.location`. In an SSR environment, this reads from `global.location` which isn't a problem on node.js, because it will just be undefined, and isn't used when doing SSR anyway. However, on [Cloudflare Workers](https://rickynguyen.medium.com/a-quick-note-about-cloudflare-worker-global-variable-e8ced503d569) there isn't any `global` object at all, so the code trying to read from `location` tries to read a global variable named `location`, which doesn't exist, so the code crashes due to an undefined variable. It is possible to enable a special Node.js compatibility mode, so the `global` will exist and `location` will be undefined rather than non-existent, but this compatibility mode gives the warning:

```
Enabling Node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details.
```

So far I have been using the compatibility mode to do SSR rendering, but it would be nice to be able to turn it off! This PR adds checks with `typeof location!="undefined"` before trying to read the variables so it works without combatibility mode.

Also, I had problems when I was doing "multipass SSR". By "multipass SSR" I mean that I was doing external fetching with promises in the SSR, then I waited for the promises to resolve, and did SSR again. When doing this, the `ssrPath` parameter was not respected for the second pass. So I also changed the semantics slightly for the `ssrPath` parameter. Now, if the `ssrPath` parameter is set, it will always be used.