### PR TITLE
V3: Router inheritance

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "eslintConfig": {
     "extends": "eslint:recommended",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 2020,
       "sourceType": "module",
       "ecmaFeatures": {
         "jsx": true

--- a/packages/wouter-preact/src/preact-deps.js
+++ b/packages/wouter-preact/src/preact-deps.js
@@ -7,6 +7,7 @@ export {
   Fragment,
 } from "preact";
 export {
+  useRef,
   useLayoutEffect as useIsomorphicLayoutEffect,
   useLayoutEffect as useInsertionEffect,
   useState,

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -92,15 +92,15 @@ export const Router = ({ children, ...props }) => {
     prev = ref.current,
     next = prev;
 
-  for (let [k, v] of Object.entries(parent)) {
+  for (let k in parent) {
     const option =
       k === "base"
         ? /* base is special case, it is appended to the parent's base */
-          v + (props[k] || "")
-        : props[k] || v;
+          parent[k] + (props[k] || "")
+        : props[k] || parent[k];
 
     if (prev === next && option !== next[k]) {
-      ref.current = next = Object.assign({}, next);
+      ref.current = next = { ...next };
     }
 
     next[k] = option;

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -4,7 +4,6 @@ import { useLocation as locationHook } from "./use-location.js";
 
 import {
   useRef,
-  useState,
   useContext,
   createContext,
   isValidElement,

--- a/packages/wouter/src/react-deps.js
+++ b/packages/wouter/src/react-deps.js
@@ -9,6 +9,7 @@ const {
 } = React;
 
 export {
+  useRef,
   useState,
   useContext,
   createContext,

--- a/packages/wouter/test/router.test.tsx
+++ b/packages/wouter/test/router.test.tsx
@@ -81,7 +81,7 @@ describe("`base` prop", () => {
     expect(result.current.base).toBe("/foo");
   });
 
-  it.skip("appends provided path to the parent router's base", () => {
+  it("appends provided path to the parent router's base", () => {
     const { result } = renderHook(() => useRouter(), {
       wrapper: (props) => (
         <Router base="/baz">
@@ -95,7 +95,7 @@ describe("`base` prop", () => {
   });
 });
 
-describe.skip("`hook` prop", () => {
+describe("`hook` prop", () => {
   it("when provided, the router isn't inherited from the parent", () => {
     const customHook: LocationHook = () => ["/foo", () => {}];
     const newParser: Parser = () => ({ pattern: /(.*)/, keys: [] });
@@ -118,7 +118,7 @@ describe.skip("`hook` prop", () => {
   });
 });
 
-it.skip("updates the context when settings are changed", () => {
+it("updates the context when settings are changed", () => {
   const state: { renders: number } & Partial<ComponentProps<typeof Router>> = {
     renders: 0,
   };


### PR DESCRIPTION
Implements `Router` component compliant with the latest spec. 
Key features:
  - `useRouter` will now cause re-render when one of the router properties is customised.
  - Router object is guaranteed to be stable (see the comment)
  - When custom `hook` prop is given, all the other parameters will reset. Consider the app, that has router B nested in router A. Router A uses browser location for page navigation, while router B uses memory location for tab switching. In that case it does not make sense for router B to inherit `base` property from A, as it is completely isolated.

