### PR TITLE
v3: use browser location

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       ]
     },
     {
-      "path": "packages/wouter/esm/use-location.js",
+      "path": "packages/wouter/esm/use-browser-location.js",
       "limit": "1000 B",
       "ignore": [
         "react",
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "path": "packages/wouter-preact/esm/use-location.js",
+      "path": "packages/wouter-preact/esm/use-browser-location.js",
       "limit": "1000 B",
       "ignore": [
         "preact",

--- a/packages/wouter-preact/rollup.config.js
+++ b/packages/wouter-preact/rollup.config.js
@@ -4,7 +4,7 @@ import { defineConfig } from "rollup";
 
 export default defineConfig([
   {
-    input: ["wouter", "wouter/use-location"],
+    input: ["wouter", "wouter/use-browser-location"],
     external: ["preact", "preact/hooks"],
 
     output: {

--- a/packages/wouter/package.json
+++ b/packages/wouter/package.json
@@ -22,9 +22,9 @@
       "types": "./types/index.d.ts",
       "default": "./esm/index.js"
     },
-    "./use-location": {
+    "./use-browser-location": {
       "types": "./types/use-location.d.ts",
-      "default": "./esm/use-location.js"
+      "default": "./esm/use-browser-location.js"
     }
   },
   "types": "types/index.d.ts",
@@ -33,7 +33,7 @@
       "types/index.d.ts": [
         "types/index.d.ts"
       ],
-      "use-location": [
+      "use-browser-location": [
         "types/use-location.d.ts"
       ]
     }

--- a/packages/wouter/rollup.config.js
+++ b/packages/wouter/rollup.config.js
@@ -14,7 +14,7 @@ export default defineConfig([
     ],
   },
   {
-    input: ["src/index.js", "src/use-location.js"],
+    input: ["src/index.js", "src/use-browser-location.js"],
     external: [/react-deps/, "regexparam"],
     output: {
       dir: "esm",

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -1,6 +1,6 @@
 import { parse as parsePattern } from "regexparam";
 
-import { useLocation as locationHook } from "./use-location.js";
+import { useBrowserLocation as locationHook } from "./use-browser-location.js";
 
 import {
   useContext,

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -1,6 +1,6 @@
 import { parse as parsePattern } from "regexparam";
 
-import { useBrowserLocation as locationHook } from "./use-browser-location.js";
+import { useBrowserLocation } from "./use-browser-location.js";
 
 import {
   useContext,
@@ -25,7 +25,7 @@ import {
  */
 
 const defaultRouter = {
-  hook: locationHook,
+  hook: useBrowserLocation,
   parser: parsePattern,
   base: "",
   // this option is used to override the current location during SSR

--- a/packages/wouter/src/use-browser-location.js
+++ b/packages/wouter/src/use-browser-location.js
@@ -43,13 +43,13 @@ export const usePathname = ({ ssrPath } = {}) =>
 export const navigate = (to, { replace = false } = {}) =>
   history[replace ? eventReplaceState : eventPushState](null, "", to);
 
-// the 2nd argument of the `useLocation` return value is a function
+// the 2nd argument of the `useBrowserLocation` return value is a function
 // that allows to perform a navigation.
 //
 // the function reference should stay the same between re-renders, so that
 // it can be passed down as an element prop without any performance concerns.
 // (This is achieved via `useEvent`.)
-export const useLocation = (opts = {}) => [
+export const useBrowserLocation = (opts = {}) => [
   relativePath(opts.base, usePathname(opts)),
   useEvent((to, navOpts) => navigate(absolutePath(to, opts.base), navOpts)),
 ];

--- a/packages/wouter/src/use-browser-location.js
+++ b/packages/wouter/src/use-browser-location.js
@@ -8,7 +8,7 @@ const eventPopstate = "popstate";
 const eventPushState = "pushState";
 const eventReplaceState = "replaceState";
 const eventHashchange = "hashchange";
-export const events = [
+const events = [
   eventPopstate,
   eventPushState,
   eventReplaceState,

--- a/packages/wouter/test/use-browser-location.test-d.ts
+++ b/packages/wouter/test/use-browser-location.test-d.ts
@@ -1,0 +1,15 @@
+import { it, assertType } from "vitest";
+import { useBrowserLocation } from "wouter/use-browser-location";
+
+it("should return string, function tuple", () => {
+  const [loc, navigate] = useBrowserLocation();
+
+  assertType<string>(loc);
+  assertType<Function>(navigate);
+});
+
+it("should support options", () => {
+  assertType(useBrowserLocation({ base: "/something" }));
+  // @ts-expect-error
+  assertType(useBrowserLocation({ foo: "bar" }));
+});

--- a/packages/wouter/test/use-browser-location.test-d.ts
+++ b/packages/wouter/test/use-browser-location.test-d.ts
@@ -8,7 +8,23 @@ it("should return string, function tuple", () => {
   assertType<Function>(navigate);
 });
 
-it("should support options", () => {
+it("should return `navigate` function with `path` and `options` parameters", () => {
+  const [, navigate] = useBrowserLocation();
+
+  assertType(navigate("/path"));
+  assertType(navigate(""));
+
+  // @ts-expect-error
+  assertType(navigate());
+  // @ts-expect-error
+  assertType(navigate(null));
+
+  assertType(navigate("/path", { replace: true }));
+  // @ts-expect-error
+  assertType(navigate("/path", { unknownOption: true }));
+});
+
+it("should support base option", () => {
   assertType(useBrowserLocation({ base: "/something" }));
   // @ts-expect-error
   assertType(useBrowserLocation({ foo: "bar" }));

--- a/packages/wouter/test/use-browser-location.test.tsx
+++ b/packages/wouter/test/use-browser-location.test.tsx
@@ -1,7 +1,11 @@
 import { useEffect } from "react";
 import { it, expect, describe, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
-import { useBrowserLocation as useLocation, navigate, useSearch } from "wouter/use-browser-location";
+import {
+  useBrowserLocation as useLocation,
+  navigate,
+  useSearch,
+} from "wouter/use-browser-location";
 
 it("returns a pair [value, update]", () => {
   const { result, unmount } = renderHook(() => useLocation());

--- a/packages/wouter/test/use-browser-location.test.tsx
+++ b/packages/wouter/test/use-browser-location.test.tsx
@@ -2,13 +2,13 @@ import { useEffect } from "react";
 import { it, expect, describe, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import {
-  useBrowserLocation as useLocation,
+  useBrowserLocation,
   navigate,
   useSearch,
 } from "wouter/use-browser-location";
 
 it("returns a pair [value, update]", () => {
-  const { result, unmount } = renderHook(() => useLocation());
+  const { result, unmount } = renderHook(() => useBrowserLocation());
   const [value, update] = result.current;
 
   expect(typeof value).toBe("string");
@@ -20,13 +20,13 @@ describe("`value` first argument", () => {
   beforeEach(() => history.replaceState(null, "", "/"));
 
   it("reflects the current pathname", () => {
-    const { result, unmount } = renderHook(() => useLocation());
+    const { result, unmount } = renderHook(() => useBrowserLocation());
     expect(result.current[0]).toBe("/");
     unmount();
   });
 
   it("reacts to `pushState` / `replaceState`", () => {
-    const { result, unmount } = renderHook(() => useLocation());
+    const { result, unmount } = renderHook(() => useBrowserLocation());
 
     act(() => history.pushState(null, "", "/foo"));
     expect(result.current[0]).toBe("/foo");
@@ -37,7 +37,7 @@ describe("`value` first argument", () => {
   });
 
   it("supports history.back() navigation", async () => {
-    const { result, unmount } = renderHook(() => useLocation());
+    const { result, unmount } = renderHook(() => useBrowserLocation());
 
     act(() => history.pushState(null, "", "/foo"));
     await waitFor(() => expect(result.current[0]).toBe("/foo"));
@@ -51,7 +51,9 @@ describe("`value` first argument", () => {
   });
 
   it("returns a pathname without a basepath", () => {
-    const { result, unmount } = renderHook(() => useLocation({ base: "/app" }));
+    const { result, unmount } = renderHook(() =>
+      useBrowserLocation({ base: "/app" })
+    );
 
     act(() => history.pushState(null, "", "/app/dashboard"));
     expect(result.current[0]).toBe("/dashboard");
@@ -59,7 +61,9 @@ describe("`value` first argument", () => {
   });
 
   it("returns `/` when URL contains only a basepath", () => {
-    const { result, unmount } = renderHook(() => useLocation({ base: "/app" }));
+    const { result, unmount } = renderHook(() =>
+      useBrowserLocation({ base: "/app" })
+    );
 
     act(() => history.pushState(null, "", "/app"));
     expect(result.current[0]).toBe("/");
@@ -68,7 +72,7 @@ describe("`value` first argument", () => {
 
   it("basepath should be case-insensitive", () => {
     const { result, unmount } = renderHook(() =>
-      useLocation({ base: "/MyApp" })
+      useBrowserLocation({ base: "/MyApp" })
     );
 
     act(() => history.pushState(null, "", "/myAPP/users/JohnDoe"));
@@ -78,7 +82,7 @@ describe("`value` first argument", () => {
 
   it("returns an absolute path in case of unmatched base path", () => {
     const { result, unmount } = renderHook(() =>
-      useLocation({ base: "/MyApp" })
+      useBrowserLocation({ base: "/MyApp" })
     );
 
     act(() => history.pushState(null, "", "/MyOtherApp/users/JohnDoe"));
@@ -96,7 +100,7 @@ describe("`value` first argument", () => {
       useEffect(() => {
         locationRenders.current += 1;
       });
-      return useLocation();
+      return useBrowserLocation();
     });
 
     const { result: searchResult, unmount: searchUnmount } = renderHook(() => {
@@ -142,7 +146,7 @@ describe("`value` first argument", () => {
 
 describe("`update` second parameter", () => {
   it("rerenders the component", () => {
-    const { result, unmount } = renderHook(() => useLocation());
+    const { result, unmount } = renderHook(() => useBrowserLocation());
     const update = result.current[1];
 
     act(() => update("/about"));
@@ -151,7 +155,7 @@ describe("`update` second parameter", () => {
   });
 
   it("changes the current location", () => {
-    const { result, unmount } = renderHook(() => useLocation());
+    const { result, unmount } = renderHook(() => useBrowserLocation());
     const update = result.current[1];
 
     act(() => update("/about"));
@@ -160,7 +164,7 @@ describe("`update` second parameter", () => {
   });
 
   it("saves a new entry in the History object", () => {
-    const { result, unmount } = renderHook(() => useLocation());
+    const { result, unmount } = renderHook(() => useBrowserLocation());
     const update = result.current[1];
 
     const histBefore = history.length;
@@ -171,7 +175,7 @@ describe("`update` second parameter", () => {
   });
 
   it("replaces last entry with a new entry in the History object", () => {
-    const { result, unmount } = renderHook(() => useLocation());
+    const { result, unmount } = renderHook(() => useBrowserLocation());
     const update = result.current[1];
 
     const histBefore = history.length;
@@ -183,7 +187,9 @@ describe("`update` second parameter", () => {
   });
 
   it("stays the same reference between re-renders (function ref)", () => {
-    const { result, rerender, unmount } = renderHook(() => useLocation());
+    const { result, rerender, unmount } = renderHook(() =>
+      useBrowserLocation()
+    );
 
     const updateWas = result.current[1];
     rerender();
@@ -194,7 +200,9 @@ describe("`update` second parameter", () => {
   });
 
   it("supports a basepath", () => {
-    const { result, unmount } = renderHook(() => useLocation({ base: "/app" }));
+    const { result, unmount } = renderHook(() =>
+      useBrowserLocation({ base: "/app" })
+    );
     const update = result.current[1];
 
     act(() => update("/dashboard"));

--- a/packages/wouter/test/use-browser-location.test.tsx
+++ b/packages/wouter/test/use-browser-location.test.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { it, expect, describe, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
-import { useLocation, navigate, useSearch } from "wouter/use-location";
+import { useBrowserLocation as useLocation, navigate, useSearch } from "wouter/use-browser-location";
 
 it("returns a pair [value, update]", () => {
   const { result, unmount } = renderHook(() => useLocation());

--- a/packages/wouter/types/type-specs.tsx
+++ b/packages/wouter/types/type-specs.tsx
@@ -11,8 +11,6 @@ import {
   useRouter,
 } from "wouter";
 
-import { useLocation as useBrowserLocation } from "wouter/use-location";
-
 const Header: React.FunctionComponent = () => <div />;
 const Profile = ({ params }: RouteComponentProps<{ id: string }>) => (
   <div>User id: {params.id}</div>
@@ -256,13 +254,3 @@ setNetworkLoc("/home", { delay: 2000 });
 
 const router = useRouter(); // $ExpectType RouterObject
 router.parent; // $ExpectType RouterObject | undefined
-
-/*
- * Standalone useLocation hook
- */
-
-const [loc, navigate] = useBrowserLocation();
-loc; // $ExpectType string
-
-useBrowserLocation({ base: "/something" });
-useBrowserLocation({ foo: "bar" }); // $ExpectError

--- a/packages/wouter/types/use-location.d.ts
+++ b/packages/wouter/types/use-location.d.ts
@@ -55,6 +55,6 @@ export type LocationHook = (options?: {
   base?: Path;
 }) => [Path, (to: Path, options?: { replace?: boolean }) => void];
 
-export const useLocation: LocationHook;
+export const useBrowserLocation: LocationHook;
 
 export type LocationTuple = HookReturnValue<LocationHook>;


### PR DESCRIPTION
first part of `use-browser-location` feature:

- Renamed `use-location`
- Named exports only
- Dropped `export const events` from module
- Migrated type specs

related to #346