### PR TITLE
`wouter/use-hash-location`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,14 @@
       ]
     },
     {
+      "path": "packages/wouter/esm/use-hash-location.js",
+      "limit": "1000 B",
+      "ignore": [
+        "react",
+        "use-sync-external-store"
+      ]
+    },
+    {
       "path": "packages/wouter-preact/esm/index.js",
       "limit": "2000 B",
       "ignore": [
@@ -52,6 +60,14 @@
     },
     {
       "path": "packages/wouter-preact/esm/use-browser-location.js",
+      "limit": "1000 B",
+      "ignore": [
+        "preact",
+        "preact/hooks"
+      ]
+    },
+    {
+      "path": "packages/wouter-preact/esm/use-hash-location.js",
       "limit": "1000 B",
       "ignore": [
         "preact",

--- a/packages/wouter-preact/package.json
+++ b/packages/wouter-preact/package.json
@@ -25,6 +25,10 @@
     "./use-browser-location": {
       "types": "./types/use-browser-location.d.ts",
       "default": "./esm/use-browser-location.js"
+    },
+    "./use-hash-location": {
+      "types": "./types/use-hash-location.d.ts",
+      "default": "./esm/use-hash-location.js"
     }
   },
   "types": "types/index.d.ts",
@@ -35,6 +39,9 @@
       ],
       "use-browser-location": [
         "types/use-browser-location.d.ts"
+      ],
+      "use-hash-location": [
+        "types/use-hash-location.d.ts"
       ]
     }
   },

--- a/packages/wouter-preact/rollup.config.js
+++ b/packages/wouter-preact/rollup.config.js
@@ -4,7 +4,12 @@ import { defineConfig } from "rollup";
 
 export default defineConfig([
   {
-    input: ["wouter", "wouter/use-browser-location", "wouter/memory-location", "wouter/use-hash-location"],
+    input: [
+      "wouter",
+      "wouter/use-browser-location",
+      "wouter/memory-location",
+      "wouter/use-hash-location",
+    ],
     external: ["preact", "preact/hooks", "regexparam", "mitt"],
 
     output: {

--- a/packages/wouter-preact/rollup.config.js
+++ b/packages/wouter-preact/rollup.config.js
@@ -4,7 +4,11 @@ import { defineConfig } from "rollup";
 
 export default defineConfig([
   {
-    input: ["wouter", "wouter/use-browser-location"],
+    input: [
+      "wouter",
+      "wouter/use-browser-location",
+      "wouter/use-hash-location",
+    ],
     external: ["preact", "preact/hooks"],
 
     output: {

--- a/packages/wouter-preact/types/use-hash-location.d.ts
+++ b/packages/wouter-preact/types/use-hash-location.d.ts
@@ -1,0 +1,8 @@
+import { Path } from "./use-browser-location";
+
+export function navigate<S = any>(to: Path, options?: { state: S }): void;
+
+export function useHashLocation(options?: {
+  base?: Path;
+  ssrPath?: Path;
+}): [Path, typeof navigate];

--- a/packages/wouter/package.json
+++ b/packages/wouter/package.json
@@ -25,6 +25,10 @@
     "./use-browser-location": {
       "types": "./types/use-browser-location.d.ts",
       "default": "./esm/use-browser-location.js"
+    },
+    "./use-hash-location": {
+      "types": "./types/use-hash-location.d.ts",
+      "default": "./esm/use-hash-location.js"
     }
   },
   "types": "types/index.d.ts",
@@ -35,6 +39,9 @@
       ],
       "use-browser-location": [
         "types/use-browser-location.d.ts"
+      ],
+      "use-hash-location": [
+        "types/use-hash-location.d.ts"
       ]
     }
   },

--- a/packages/wouter/rollup.config.js
+++ b/packages/wouter/rollup.config.js
@@ -14,7 +14,11 @@ export default defineConfig([
     ],
   },
   {
-    input: ["src/index.js", "src/use-browser-location.js"],
+    input: [
+      "src/index.js",
+      "src/use-browser-location.js",
+      "src/use-hash-location.js",
+    ],
     external: [/react-deps/, "regexparam"],
     output: {
       dir: "esm",

--- a/packages/wouter/src/use-hash-location.js
+++ b/packages/wouter/src/use-hash-location.js
@@ -1,7 +1,8 @@
 import { useSyncExternalStore, useEvent } from "./react-deps.js";
 import { absolutePath, relativePath } from "./paths.js";
 
-// fortunately `hashchange` is a native event, so there is need to patch `history` object
+// fortunately `hashchange` is a native event, so there is no need to
+// patch `history` object (unlike `pushState/replaceState` events)
 const subscribeToHashUpdates = (callback) => {
   addEventListener("hashchange", callback);
   return () => removeEventListener("hashchange", callback);
@@ -10,8 +11,14 @@ const subscribeToHashUpdates = (callback) => {
 // leading '#' is ignored, leading '/' is optional
 const currentHashLocation = () => "/" + location.hash.replace(/^#?\/?/, "");
 
-export const navigate = (to, _options = {}) => {
-  location.hash = `/${to.replace(/^#?\/?/, "")}`;
+export const navigate = (to, { state = null } = {}) => {
+  history.pushState(
+    state,
+    "",
+    // keep the current pathname, current query string, but replace the hash
+    // (leading '#' and '/' are optional, see above)
+    location.pathname + location.search + `#/${to.replace(/^#?\/?/, "")}`
+  );
 };
 
 export const useHashLocation = ({ base, ssrPath = "/" } = {}) => [

--- a/packages/wouter/src/use-hash-location.js
+++ b/packages/wouter/src/use-hash-location.js
@@ -1,0 +1,28 @@
+import { useSyncExternalStore, useEvent } from "./react-deps.js";
+import { absolutePath, relativePath } from "./paths.js";
+
+// fortunately `hashchange` is a native event, so there is need to patch `history` object
+const subscribeToHashUpdates = (callback) => {
+  addEventListener("hashchange", callback);
+  return () => removeEventListener("hashchange", callback);
+};
+
+// leading '#' is ignored, leading '/' is optional
+const currentHashLocation = () => "/" + location.hash.replace(/^#?\/?/, "");
+
+export const navigate = (to, _options = {}) => {
+  location.hash = `/${to.replace(/^#?\/?/, "")}`;
+};
+
+export const useHashLocation = ({ base, ssrPath = "/" } = {}) => [
+  relativePath(
+    base,
+    useSyncExternalStore(
+      subscribeToHashUpdates,
+      currentHashLocation,
+      () => ssrPath
+    )
+  ),
+
+  useEvent((to, navOpts) => navigate(absolutePath(to, base), navOpts)),
+];

--- a/packages/wouter/test/test-utils.tsx
+++ b/packages/wouter/test/test-utils.tsx
@@ -55,3 +55,29 @@ export const customHookWithReturn =
 
     return [path, navigate];
   };
+
+/**
+ * Executes a callback and returns a promise that resolve when `hashchange` event is fired.
+ * Rejects after `throwAfter` milliseconds.
+ */
+export const waitForHashChangeEvent = async (
+  cb: () => void,
+  throwAfter = 1000
+) =>
+  new Promise<void>((resolve, reject) => {
+    let timeout: ReturnType<typeof setTimeout>;
+
+    const onChange = () => {
+      resolve();
+      clearTimeout(timeout);
+      window.removeEventListener("hashchange", onChange);
+    };
+
+    window.addEventListener("hashchange", onChange);
+    cb();
+
+    timeout = setTimeout(() => {
+      reject(new Error("Timed out: `hashchange` event did not fire!"));
+      window.removeEventListener("hashchange", onChange);
+    }, throwAfter);
+  });

--- a/packages/wouter/test/use-hash-location.test-d.ts
+++ b/packages/wouter/test/use-hash-location.test-d.ts
@@ -1,0 +1,31 @@
+import { it, assertType, describe, expectTypeOf } from "vitest";
+import { useHashLocation, navigate } from "wouter/use-hash-location";
+import { BaseLocationHook } from "wouter/use-browser-location";
+
+it("is a location hook", () => {
+  expectTypeOf(useHashLocation).toMatchTypeOf<BaseLocationHook>();
+  expectTypeOf(useHashLocation()).toMatchTypeOf<[string, Function]>();
+});
+
+it("accepts a `base` path option", () => {
+  useHashLocation({ base: "/foo" });
+  useHashLocation({ base: "" });
+
+  // @ts-expect-error
+  useHashLocation({ base: 123 });
+  // @ts-expect-error
+  useHashLocation({ unknown: "/base" });
+});
+
+describe("`navigate` function", () => {
+  it("accepts an arbitrary `state` option", () => {
+    navigate("/object", { state: { foo: "bar" } });
+    navigate("/symbol", { state: Symbol("foo") });
+    navigate("/string", { state: "foo" });
+    navigate("/undef", { state: undefined });
+  });
+
+  it("returns nothing", () => {
+    assertType<void>(navigate("/foo"));
+  });
+});

--- a/packages/wouter/test/use-hash-location.test.tsx
+++ b/packages/wouter/test/use-hash-location.test.tsx
@@ -1,0 +1,94 @@
+import { it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const useHashLocation = (): [string, (to: string) => void] => [
+  "/",
+  (to: string) => {},
+];
+
+beforeEach(() => {
+  history.replaceState(null, "", "/");
+  location.hash = "";
+});
+
+it("gets current location from `location.hash`", () => {
+  location.hash = "/app/users";
+  const { result } = renderHook(() => useHashLocation());
+  const [path] = result.current;
+
+  expect(path).toBe("/app/users");
+});
+
+it("isn't sensitive to leading slash", () => {
+  location.hash = "app/users";
+  const { result } = renderHook(() => useHashLocation());
+  const [path] = result.current;
+
+  expect(path).toBe("/app/users");
+});
+
+it("rerenders when hash changes", () => {
+  const { result } = renderHook(() => useHashLocation());
+  const [path] = result.current;
+
+  expect(path).toBe("/");
+
+  act(() => {
+    location.hash = "/app/users";
+  });
+
+  expect(result.current[0]).toBe("/app/users");
+});
+
+it("changes current hash when navigation is performed", () => {
+  const { result } = renderHook(() => useHashLocation());
+  const [, navigate] = result.current;
+
+  navigate("/app/users");
+  expect(location.hash).toBe("#/app/users");
+});
+
+it("should not rerender when pathname changes", () => {
+  let renderCount = 0;
+  location.hash = "/app";
+
+  const { result } = renderHook(() => {
+    useHashLocation();
+    return ++renderCount;
+  });
+
+  expect(result.current).toBe(1);
+  act(() => {
+    history.replaceState(null, "", "/foo?bar#/app");
+  });
+
+  expect(result.current).toBe(1);
+});
+
+it("does not change anything besides the hash", () => {
+  history.replaceState(null, "", "/foo?bar#/app");
+
+  const { result } = renderHook(() => useHashLocation());
+  const [, navigate] = result.current;
+
+  navigate("/settings/general");
+  expect(location.pathname).toBe("/foo");
+  expect(location.search).toBe("?bar");
+});
+
+it("supports `state` option when navigating", () => {
+  const { result } = renderHook(() => useHashLocation());
+  const [, navigate] = result.current;
+
+  navigate("/app/users", { state: { hello: "world" } });
+  expect(history.state).toStrictEqual({ hello: "world" });
+});
+
+it("never changes reference to `navigate` between rerenders", () => {
+  const { result, rerender } = renderHook(() => useHashLocation());
+
+  const updateWas = result.current[1];
+  rerender();
+
+  expect(result.current[1]).toBe(updateWas);
+});

--- a/packages/wouter/test/use-hash-location.test.tsx
+++ b/packages/wouter/test/use-hash-location.test.tsx
@@ -72,7 +72,16 @@ it("does not change anything besides the hash", () => {
   expect(location.search).toBe("?bar");
 });
 
-it.todo("supports `state` option when navigating", () => {
+it("creates a new history entry when navigating", () => {
+  const { result } = renderHook(() => useHashLocation());
+  const [, navigate] = result.current;
+
+  const initialLength = history.length;
+  navigate("/about");
+  expect(history.length).toBe(initialLength + 1);
+});
+
+it("supports `state` option when navigating", () => {
   const { result } = renderHook(() => useHashLocation());
   const [, navigate] = result.current;
 

--- a/packages/wouter/types/use-hash-location.d.ts
+++ b/packages/wouter/types/use-hash-location.d.ts
@@ -1,0 +1,5 @@
+// TODO!
+export function useHashLocation(options?: {
+  base?: string;
+  ssrPath?: string;
+}): [string, (to: string, options: { state: any }) => void];

--- a/packages/wouter/types/use-hash-location.d.ts
+++ b/packages/wouter/types/use-hash-location.d.ts
@@ -2,4 +2,4 @@
 export function useHashLocation(options?: {
   base?: string;
   ssrPath?: string;
-}): [string, (to: string, options: { state: any }) => void];
+}): [string, (to: string, options?: { state: any }) => void];

--- a/packages/wouter/types/use-hash-location.d.ts
+++ b/packages/wouter/types/use-hash-location.d.ts
@@ -1,5 +1,8 @@
-// TODO!
+import { Path } from "./use-browser-location";
+
+export function navigate<S = any>(to: Path, options?: { state: S }): void;
+
 export function useHashLocation(options?: {
-  base?: string;
-  ssrPath?: string;
-}): [string, (to: string, options?: { state: any }) => void];
+  base?: Path;
+  ssrPath?: Path;
+}): [Path, typeof navigate];


### PR DESCRIPTION
Fully functional hash location hook with base path support. Also, it can accept `state` when navigating (similarly to React Router). In order to change the state, I had to use `pushState` that keeps pathname and search untouched.

This hook also guarantees to react only to hash changes, e.g. when the search string is modified it won't rerender. Navigation isn't sensitive to leading slash, because, unlike `pathname` it can be missing.
 
- [x] support `state`
- [x] types