### PR TITLE
Fix: index.d.ts needs to import Params

### DIFF
--- a/types/ts4.1/index.d.ts
+++ b/types/ts4.1/index.d.ts
@@ -20,7 +20,7 @@ import {
   LocationHook,
 } from "../use-location";
 
-import { DefaultParams, Match } from "../matcher";
+import { DefaultParams, Params, Match } from "../matcher";
 import { RouterObject, RouterOptions } from "../router";
 
 // re-export some types from these modules


### PR DESCRIPTION
This PR adds a missing import to `index.d.ts`. Without this fix TypeScript will give the following error when you have wouter as a dependency:

```
node_modules/.pnpm/wouter@2.12.0_react@18.2.0/node_modules/wouter/types/ts4.1/index.d.ts:169:71 - error TS2304: Cannot find name 'Params'.

169 export function useParams<T extends DefaultParams = DefaultParams>(): Params<T>;
```