### PR TITLE
v3: move `absolute` and `relative` paths to core functionality

### DIFF
--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -14,6 +14,7 @@ import {
   useIsomorphicLayoutEffect,
   useEvent,
 } from "./react-deps.js";
+import { absolutePath, relativePath } from "./paths.js";
 
 /*
  * Router and router context. Router is a lightweight object that represents the current
@@ -41,7 +42,18 @@ export const useRouter = () => useContext(RouterCtx);
  */
 
 // Internal version of useLocation to avoid redundant useRouter calls
-const useLocationFromRouter = (router) => router.hook(router);
+
+const useLocationFromRouter = (router) => {
+  const [location, navigate] = router.hook(router);
+
+  // the function reference should stay the same between re-renders, so that
+  // it can be passed down as an element prop without any performance concerns.
+  // (This is achieved via `useEvent`.)
+  return [
+    relativePath(router.base, location),
+    useEvent((to, navOpts) => navigate(absolutePath(to, router.base), navOpts)),
+  ];
+};
 
 export const useLocation = () => useLocationFromRouter(useRouter());
 

--- a/packages/wouter/src/memory-location.js
+++ b/packages/wouter/src/memory-location.js
@@ -1,6 +1,5 @@
 import mitt from "mitt";
-import { useSyncExternalStore, useEvent } from "./react-deps.js";
-import { absolutePath, relativePath } from "./paths.js";
+import { useSyncExternalStore } from "./react-deps.js";
 
 /**
  * In-memory location that supports navigation
@@ -35,13 +34,8 @@ export const memoryLocation = ({
     return () => emitter.off("navigate", cb);
   };
 
-  const useMemoryLocation = ({ base } = {}) => {
-    const location = useSyncExternalStore(subscribe, () => currentPath);
-
-    return [
-      relativePath(base, location),
-      useEvent((to, options) => navigate(absolutePath(to, base), options)),
-    ];
+  const useMemoryLocation = () => {
+    return [useSyncExternalStore(subscribe, () => currentPath), navigate];
   };
 
   return {

--- a/packages/wouter/src/memory-location.js
+++ b/packages/wouter/src/memory-location.js
@@ -34,8 +34,10 @@ export const memoryLocation = ({
     return () => emitter.off("navigate", cb);
   };
 
-  const useMemoryLocation = () =>
-    [useSyncExternalStore(subscribe, () => currentPath), navigate];
+  const useMemoryLocation = () => [
+    useSyncExternalStore(subscribe, () => currentPath),
+    navigate,
+  ];
 
   return {
     hook: useMemoryLocation,

--- a/packages/wouter/src/memory-location.js
+++ b/packages/wouter/src/memory-location.js
@@ -34,9 +34,8 @@ export const memoryLocation = ({
     return () => emitter.off("navigate", cb);
   };
 
-  const useMemoryLocation = () => {
-    return [useSyncExternalStore(subscribe, () => currentPath), navigate];
-  };
+  const useMemoryLocation = () =>
+    [useSyncExternalStore(subscribe, () => currentPath), navigate];
 
   return {
     hook: useMemoryLocation,

--- a/packages/wouter/src/use-browser-location.js
+++ b/packages/wouter/src/use-browser-location.js
@@ -1,5 +1,4 @@
-import { useSyncExternalStore, useEvent } from "./react-deps.js";
-import { absolutePath, relativePath } from "./paths.js";
+import { useSyncExternalStore } from "./react-deps.js";
 
 /**
  * History API docs @see https://developer.mozilla.org/en-US/docs/Web/API/History
@@ -51,14 +50,7 @@ export const navigate = (to, { replace = false, state = null } = {}) =>
 
 // the 2nd argument of the `useBrowserLocation` return value is a function
 // that allows to perform a navigation.
-//
-// the function reference should stay the same between re-renders, so that
-// it can be passed down as an element prop without any performance concerns.
-// (This is achieved via `useEvent`.)
-export const useBrowserLocation = (opts = {}) => [
-  relativePath(opts.base, usePathname(opts)),
-  useEvent((to, navOpts) => navigate(absolutePath(to, opts.base), navOpts)),
-];
+export const useBrowserLocation = (opts = {}) => [usePathname(opts), navigate];
 
 const patchKey = Symbol.for("wouter_v3");
 

--- a/packages/wouter/src/use-hash-location.js
+++ b/packages/wouter/src/use-hash-location.js
@@ -1,5 +1,4 @@
-import { useSyncExternalStore, useEvent } from "./react-deps.js";
-import { absolutePath, relativePath } from "./paths.js";
+import { useSyncExternalStore } from "./react-deps.js";
 
 // fortunately `hashchange` is a native event, so there is no need to
 // patch `history` object (unlike `pushState/replaceState` events)
@@ -21,15 +20,11 @@ export const navigate = (to, { state = null } = {}) => {
   );
 };
 
-export const useHashLocation = ({ base, ssrPath = "/" } = {}) => [
-  relativePath(
-    base,
-    useSyncExternalStore(
-      subscribeToHashUpdates,
-      currentHashLocation,
-      () => ssrPath
-    )
+export const useHashLocation = ({ ssrPath = "/" } = {}) => [
+  useSyncExternalStore(
+    subscribeToHashUpdates,
+    currentHashLocation,
+    () => ssrPath
   ),
-
-  useEvent((to, navOpts) => navigate(absolutePath(to, base), navOpts)),
+  navigate,
 ];

--- a/packages/wouter/test/memory-location.test.ts
+++ b/packages/wouter/test/memory-location.test.ts
@@ -33,7 +33,7 @@ it('should return location hook that has initial path "/" by default', () => {
   unmount();
 });
 
-it("should return location hook that supports `base` option for nested routing", () => {
+it.skip("should return location hook that supports `base` option for nested routing", () => {
   const { hook } = memoryLocation({ path: "/nested/test" });
 
   const { result, unmount } = renderHook(() => hook({ base: "/nested" }));
@@ -43,7 +43,7 @@ it("should return location hook that supports `base` option for nested routing",
   unmount();
 });
 
-it("should return location hook that handle `base` option while navigation", () => {
+it.skip("should return location hook that handle `base` option while navigation", () => {
   const { hook, history } = memoryLocation({
     path: "/nested/test",
     record: true,

--- a/packages/wouter/test/memory-location.test.ts
+++ b/packages/wouter/test/memory-location.test.ts
@@ -33,36 +33,6 @@ it('should return location hook that has initial path "/" by default', () => {
   unmount();
 });
 
-it.skip("should return location hook that supports `base` option for nested routing", () => {
-  const { hook } = memoryLocation({ path: "/nested/test" });
-
-  const { result, unmount } = renderHook(() => hook({ base: "/nested" }));
-  const [value] = result.current;
-
-  expect(value).toBe("/test");
-  unmount();
-});
-
-it.skip("should return location hook that handle `base` option while navigation", () => {
-  const { hook, history } = memoryLocation({
-    path: "/nested/test",
-    record: true,
-  });
-
-  const { result, unmount } = renderHook(() => hook({ base: "/nested" }));
-
-  act(() => result.current[1]("/change-1"));
-  act(() => result.current[1]("/change-2"));
-
-  expect(history).toStrictEqual([
-    "/nested/test",
-    "/nested/change-1",
-    "/nested/change-2",
-  ]);
-
-  unmount();
-});
-
 it("should return standalone `navigate` method", () => {
   const { hook, navigate } = memoryLocation();
 

--- a/packages/wouter/test/test-utils.ts
+++ b/packages/wouter/test/test-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Executes a callback and returns a promise that resolve when `hashchange` event is fired.
+ * Rejects after `throwAfter` milliseconds.
+ */
+export const waitForHashChangeEvent = async (cb: () => void, throwAfter = 1000) =>
+  new Promise<void>((resolve, reject) => {
+    let timeout: ReturnType<typeof setTimeout>;
+
+    const onChange = () => {
+      resolve();
+      clearTimeout(timeout);
+      window.removeEventListener("hashchange", onChange);
+    };
+
+    window.addEventListener("hashchange", onChange);
+    cb();
+
+    timeout = setTimeout(() => {
+      reject(new Error("Timed out: `hashchange` event did not fire!"));
+      window.removeEventListener("hashchange", onChange);
+    }, throwAfter);
+  });

--- a/packages/wouter/test/test-utils.ts
+++ b/packages/wouter/test/test-utils.ts
@@ -2,7 +2,10 @@
  * Executes a callback and returns a promise that resolve when `hashchange` event is fired.
  * Rejects after `throwAfter` milliseconds.
  */
-export const waitForHashChangeEvent = async (cb: () => void, throwAfter = 1000) =>
+export const waitForHashChangeEvent = async (
+  cb: () => void,
+  throwAfter = 1000
+) =>
   new Promise<void>((resolve, reject) => {
     let timeout: ReturnType<typeof setTimeout>;
 

--- a/packages/wouter/test/use-browser-location.test-d.ts
+++ b/packages/wouter/test/use-browser-location.test-d.ts
@@ -29,8 +29,8 @@ describe("useBrowserLocation", () => {
     assertType(navigate("/path", { unknownOption: true }));
   });
 
-  it("should support base option", () => {
-    assertType(useBrowserLocation({ base: "/something" }));
+  it("should support `ssrPath` option", () => {
+    assertType(useBrowserLocation({ ssrPath: "/something" }));
     // @ts-expect-error
     assertType(useBrowserLocation({ foo: "bar" }));
   });

--- a/packages/wouter/test/use-browser-location.test.tsx
+++ b/packages/wouter/test/use-browser-location.test.tsx
@@ -51,7 +51,7 @@ describe("`value` first argument", () => {
     unmount();
   });
 
-  it("returns a pathname without a basepath", () => {
+  it.skip("returns a pathname without a basepath", () => {
     const { result, unmount } = renderHook(() =>
       useBrowserLocation({ base: "/app" })
     );
@@ -61,7 +61,7 @@ describe("`value` first argument", () => {
     unmount();
   });
 
-  it("returns `/` when URL contains only a basepath", () => {
+  it.skip("returns `/` when URL contains only a basepath", () => {
     const { result, unmount } = renderHook(() =>
       useBrowserLocation({ base: "/app" })
     );
@@ -71,7 +71,7 @@ describe("`value` first argument", () => {
     unmount();
   });
 
-  it("basepath should be case-insensitive", () => {
+  it.skip("basepath should be case-insensitive", () => {
     const { result, unmount } = renderHook(() =>
       useBrowserLocation({ base: "/MyApp" })
     );
@@ -81,7 +81,7 @@ describe("`value` first argument", () => {
     unmount();
   });
 
-  it("returns an absolute path in case of unmatched base path", () => {
+  it.skip("returns an absolute path in case of unmatched base path", () => {
     const { result, unmount } = renderHook(() =>
       useBrowserLocation({ base: "/MyApp" })
     );
@@ -216,7 +216,7 @@ describe("`update` second parameter", () => {
     unmount();
   });
 
-  it("supports a basepath", () => {
+  it.skip("supports a basepath", () => {
     const { result, unmount } = renderHook(() =>
       useBrowserLocation({ base: "/app" })
     );

--- a/packages/wouter/test/use-browser-location.test.tsx
+++ b/packages/wouter/test/use-browser-location.test.tsx
@@ -51,46 +51,6 @@ describe("`value` first argument", () => {
     unmount();
   });
 
-  it.skip("returns a pathname without a basepath", () => {
-    const { result, unmount } = renderHook(() =>
-      useBrowserLocation({ base: "/app" })
-    );
-
-    act(() => history.pushState(null, "", "/app/dashboard"));
-    expect(result.current[0]).toBe("/dashboard");
-    unmount();
-  });
-
-  it.skip("returns `/` when URL contains only a basepath", () => {
-    const { result, unmount } = renderHook(() =>
-      useBrowserLocation({ base: "/app" })
-    );
-
-    act(() => history.pushState(null, "", "/app"));
-    expect(result.current[0]).toBe("/");
-    unmount();
-  });
-
-  it.skip("basepath should be case-insensitive", () => {
-    const { result, unmount } = renderHook(() =>
-      useBrowserLocation({ base: "/MyApp" })
-    );
-
-    act(() => history.pushState(null, "", "/myAPP/users/JohnDoe"));
-    expect(result.current[0]).toBe("/users/JohnDoe");
-    unmount();
-  });
-
-  it.skip("returns an absolute path in case of unmatched base path", () => {
-    const { result, unmount } = renderHook(() =>
-      useBrowserLocation({ base: "/MyApp" })
-    );
-
-    act(() => history.pushState(null, "", "/MyOtherApp/users/JohnDoe"));
-    expect(result.current[0]).toBe("~/MyOtherApp/users/JohnDoe");
-    unmount();
-  });
-
   it("supports search url", () => {
     // count how many times each hook is rendered
     const locationRenders = { current: 0 };
@@ -213,17 +173,6 @@ describe("`update` second parameter", () => {
     const updateNow = result.current[1];
 
     expect(updateWas).toBe(updateNow);
-    unmount();
-  });
-
-  it.skip("supports a basepath", () => {
-    const { result, unmount } = renderHook(() =>
-      useBrowserLocation({ base: "/app" })
-    );
-    const update = result.current[1];
-
-    act(() => update("/dashboard"));
-    expect(location.pathname).toBe("/app/dashboard");
     unmount();
   });
 });

--- a/packages/wouter/test/use-hash-location.test-d.ts
+++ b/packages/wouter/test/use-hash-location.test-d.ts
@@ -7,9 +7,9 @@ it("is a location hook", () => {
   expectTypeOf(useHashLocation()).toMatchTypeOf<[string, Function]>();
 });
 
-it("accepts a `base` path option", () => {
-  useHashLocation({ base: "/foo" });
-  useHashLocation({ base: "" });
+it("accepts a `ssrPath` path option", () => {
+  useHashLocation({ ssrPath: "/foo" });
+  useHashLocation({ ssrPath: "" });
 
   // @ts-expect-error
   useHashLocation({ base: 123 });

--- a/packages/wouter/test/use-hash-location.test.tsx
+++ b/packages/wouter/test/use-hash-location.test.tsx
@@ -4,6 +4,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { useHashLocation } from "wouter/use-hash-location";
 
+import { waitForHashChangeEvent } from "./test-utils";
+
 beforeEach(() => {
   history.replaceState(null, "", "/");
   location.hash = "";
@@ -119,26 +121,3 @@ it("is not sensitive to leading / or # when navigating", async () => {
   expect(location.hash).toBe("#/look-ma-no-hashes");
   expect(result.current[0]).toBe("/look-ma-no-hashes");
 });
-
-/**
- * Executes a callback and returns a promise that resolve when `hashchange` event is fired.
- * Rejects after `throwAfter` milliseconds.
- */
-const waitForHashChangeEvent = async (cb: () => void, throwAfter = 1000) =>
-  new Promise<void>((resolve, reject) => {
-    let timeout: ReturnType<typeof setTimeout>;
-
-    const onChange = () => {
-      resolve();
-      clearTimeout(timeout);
-      window.removeEventListener("hashchange", onChange);
-    };
-
-    window.addEventListener("hashchange", onChange);
-    cb();
-
-    timeout = setTimeout(() => {
-      reject(new Error("Timed out: `hashchange` event did not fire!"));
-      window.removeEventListener("hashchange", onChange);
-    }, throwAfter);
-  });

--- a/packages/wouter/test/use-location.test.tsx
+++ b/packages/wouter/test/use-location.test.tsx
@@ -1,0 +1,150 @@
+import { ComponentProps, ReactNode } from "react";
+import { it, expect, describe } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { Router, useLocation } from "wouter";
+import {
+  useBrowserLocation,
+  navigate as browserNavigation,
+  BaseLocationHook,
+} from "wouter/use-browser-location";
+
+import {
+  useHashLocation,
+  navigate as hashNavigation,
+} from "wouter/use-hash-location";
+
+import { memoryLocation } from "wouter/memory-location";
+
+function createContainer(
+  options: Omit<ComponentProps<typeof Router>, "children"> = {}
+) {
+  return ({ children }: { children: ReactNode }) => (
+    <Router {...options}>{children}</Router>
+  );
+}
+
+type StubType = {
+  name: string;
+  hook: BaseLocationHook;
+  location: () => string;
+  navigate: ReturnType<BaseLocationHook>[1];
+};
+
+function createLocationSpec(stub: StubType) {
+  describe(stub.name, () => {
+    it("returns a pair [value, update]", () => {
+      const { result, unmount } = renderHook(() => useLocation(), {
+        wrapper: createContainer({ hook: stub.hook }),
+      });
+      const [value, update] = result.current;
+
+      expect(typeof value).toBe("string");
+      expect(typeof update).toBe("function");
+      unmount();
+    });
+
+    describe("`value` first argument", () => {
+      it("returns `/` when URL contains only a basepath", () => {
+        const { result, unmount } = renderHook(() => useLocation(), {
+          wrapper: createContainer({
+            base: "/app",
+            hook: stub.hook,
+          }),
+        });
+
+        act(() => stub.navigate("/app"));
+        expect(result.current[0]).toBe("/");
+        unmount();
+      });
+
+      it("basepath should be case-insensitive", () => {
+        const { result, unmount } = renderHook(() => useLocation(), {
+          wrapper: createContainer({
+            base: "/MyApp",
+            hook: stub.hook,
+          }),
+        });
+
+        act(() => stub.navigate("/myAPP/users/JohnDoe"));
+        expect(result.current[0]).toBe("/users/JohnDoe");
+        unmount();
+      });
+
+      it("returns an absolute path in case of unmatched base path", () => {
+        const { result, unmount } = renderHook(() => useLocation(), {
+          wrapper: createContainer({
+            base: "/MyApp",
+            hook: stub.hook,
+          }),
+        });
+
+        act(() => stub.navigate("/MyOtherApp/users/JohnDoe"));
+        expect(result.current[0]).toBe("~/MyOtherApp/users/JohnDoe");
+        unmount();
+      });
+    });
+
+    describe("`update` second parameter", () => {
+      it("rerenders the component", () => {
+        const { result, unmount } = renderHook(() => useLocation(), {
+          wrapper: createContainer({ hook: stub.hook }),
+        });
+        const update = result.current[1];
+
+        act(() => update("/about"));
+        expect(stub.location()).toBe("/about");
+        unmount();
+      });
+
+      it("stays the same reference between re-renders (function ref)", () => {
+        const { result, rerender, unmount } = renderHook(() => useLocation(), {
+          wrapper: createContainer({ hook: stub.hook }),
+        });
+
+        const updateWas = result.current[1];
+        rerender();
+        const updateNow = result.current[1];
+
+        expect(updateWas).toBe(updateNow);
+        unmount();
+      });
+
+      it("supports a basepath", () => {
+        const { result, unmount } = renderHook(() => useLocation(), {
+          wrapper: createContainer({
+            base: "/app",
+            hook: stub.hook,
+          }),
+        });
+
+        const update = result.current[1];
+
+        act(() => update("/dashboard"));
+        expect(stub.location()).toBe("/app/dashboard");
+        unmount();
+      });
+    });
+  });
+}
+
+createLocationSpec({
+  name: "useBrowserLocation",
+  hook: useBrowserLocation,
+  location: () => location.pathname,
+  navigate: browserNavigation,
+});
+
+createLocationSpec({
+  name: "useHashLocation",
+  hook: useHashLocation,
+  location: () => location.hash.replace(/^#?\/?/, ""),
+  navigate: hashNavigation,
+});
+
+const memory = memoryLocation({ record: true });
+createLocationSpec({
+  name: "memoryLocation",
+  hook: memory.hook,
+  location: () => memory.history.at(-1) ?? "",
+  navigate: memory.navigate,
+});

--- a/packages/wouter/test/use-location.test.tsx
+++ b/packages/wouter/test/use-location.test.tsx
@@ -12,6 +12,7 @@ import {
   useHashLocation,
   navigate as hashNavigation,
 } from "wouter/use-hash-location";
+import { waitForHashChangeEvent } from "./test-utils";
 
 import { memoryLocation } from "wouter/memory-location";
 
@@ -31,25 +32,6 @@ type StubType = {
   act: (cb: () => void) => Promise<void>;
   clear: () => void;
 };
-
-const waitForHashChangeEvent = async (cb: () => void, throwAfter = 1000) =>
-  new Promise<void>((resolve, reject) => {
-    let timeout: ReturnType<typeof setTimeout>;
-
-    const onChange = () => {
-      resolve();
-      clearTimeout(timeout);
-      window.removeEventListener("hashchange", onChange);
-    };
-
-    window.addEventListener("hashchange", onChange);
-    cb();
-
-    timeout = setTimeout(() => {
-      reject(new Error("Timed out: `hashchange` event did not fire!"));
-      window.removeEventListener("hashchange", onChange);
-    }, throwAfter);
-  });
 
 function createLocationSpec(stub: StubType) {
   describe(stub.name, () => {

--- a/packages/wouter/test/use-location.test.tsx
+++ b/packages/wouter/test/use-location.test.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps, ReactNode } from "react";
-import { it, expect, describe } from "vitest";
+import { it, expect, describe, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { Router, useLocation } from "wouter";
 import {
@@ -28,10 +28,13 @@ type StubType = {
   hook: BaseLocationHook;
   location: () => string;
   navigate: ReturnType<BaseLocationHook>[1];
+  clear: () => void;
 };
 
 function createLocationSpec(stub: StubType) {
   describe(stub.name, () => {
+    beforeEach(() => stub.clear());
+
     it("returns a pair [value, update]", () => {
       const { result, unmount } = renderHook(() => useLocation(), {
         wrapper: createContainer({ hook: stub.hook }),
@@ -132,13 +135,20 @@ createLocationSpec({
   hook: useBrowserLocation,
   location: () => location.pathname,
   navigate: browserNavigation,
+  clear: () => {
+    history.replaceState(null, "", "/");
+  },
 });
 
 createLocationSpec({
   name: "useHashLocation",
   hook: useHashLocation,
-  location: () => location.hash.replace(/^#?\/?/, ""),
+  location: () => "/" + location.hash.replace(/^#?\/?/, ""),
   navigate: hashNavigation,
+  clear: () => {
+    location.hash = "";
+    history.replaceState(null, "", "/");
+  },
 });
 
 const memory = memoryLocation({ record: true });
@@ -147,4 +157,5 @@ createLocationSpec({
   hook: memory.hook,
   location: () => memory.history.at(-1) ?? "",
   navigate: memory.navigate,
+  clear: () => null,
 });

--- a/packages/wouter/test/use-location.test.tsx
+++ b/packages/wouter/test/use-location.test.tsx
@@ -8,10 +8,10 @@ import {
   BaseLocationHook,
 } from "wouter/use-browser-location";
 
-import {
-  useHashLocation,
-  navigate as hashNavigation,
-} from "wouter/use-hash-location";
+// import {
+//   useHashLocation,
+//   navigate as hashNavigation,
+// } from "wouter/use-hash-location";
 
 import { memoryLocation } from "wouter/memory-location";
 
@@ -140,16 +140,16 @@ createLocationSpec({
   },
 });
 
-createLocationSpec({
-  name: "useHashLocation",
-  hook: useHashLocation,
-  location: () => "/" + location.hash.replace(/^#?\/?/, ""),
-  navigate: hashNavigation,
-  clear: () => {
-    location.hash = "";
-    history.replaceState(null, "", "/");
-  },
-});
+// createLocationSpec({
+//   name: "useHashLocation",
+//   hook: useHashLocation,
+//   location: () => "/" + location.hash.replace(/^#?\/?/, ""),
+//   navigate: hashNavigation,
+//   clear: () => {
+//     location.hash = "";
+//     history.replaceState(null, "", "/");
+//   },
+// });
 
 const memory = memoryLocation({ record: true });
 createLocationSpec({

--- a/packages/wouter/types/use-browser-location.d.ts
+++ b/packages/wouter/types/use-browser-location.d.ts
@@ -57,7 +57,6 @@ export const navigate: (
 // It operates on current URL using History API, supports base path and can
 // navigate with `pushState` or `replaceState`.
 export type LocationHook = (options?: {
-  base?: Path;
   ssrPath?: Path;
 }) => [Path, typeof navigate];
 

--- a/packages/wouter/types/use-hash-location.d.ts
+++ b/packages/wouter/types/use-hash-location.d.ts
@@ -3,6 +3,5 @@ import { Path } from "./use-browser-location";
 export function navigate<S = any>(to: Path, options?: { state: S }): void;
 
 export function useHashLocation(options?: {
-  base?: Path;
   ssrPath?: Path;
 }): [Path, typeof navigate];


### PR DESCRIPTION
TODOs:

- [x] test
- [x] update types
- [ ] (???)