### PR TITLE
`useSearch` is part of `"wouter"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "size-limit": [
     {
       "path": "packages/wouter/esm/index.js",
-      "limit": "2100 B",
+      "limit": "2500 B",
       "ignore": [
         "react",
         "use-sync-external-store"

--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -14,13 +14,14 @@ import {
   BaseLocationHook,
   HookReturnValue,
   HookNavigationOptions,
+  BaseSearchHook,
 } from "./location-hook";
-import { BrowserLocationHook } from "./use-browser-location";
+import { BrowserLocationHook, BrowserSearchHook } from "./use-browser-location";
 
 import { RouterObject, RouterOptions } from "./router";
 
 // re-export some types from these modules
-export { Path, BaseLocationHook } from "./location-hook";
+export { Path, BaseLocationHook, BaseSearchHook } from "./location-hook";
 export * from "./router";
 
 import { RouteParams } from "regexparam";
@@ -136,6 +137,10 @@ export function useRoute<
 export function useLocation<
   H extends BaseLocationHook = BrowserLocationHook
 >(): HookReturnValue<H>;
+
+export function useSearch<
+  H extends BaseSearchHook = BrowserSearchHook
+>(): ReturnType<H>;
 
 export function useParams<T = undefined>(): T extends string
   ? RouteParams<T>

--- a/packages/wouter-preact/types/location-hook.d.ts
+++ b/packages/wouter-preact/types/location-hook.d.ts
@@ -4,11 +4,15 @@
 
 export type Path = string;
 
+export type SearchString = string;
+
 // the base useLocation hook type. Any custom hook (including the
 // default one) should inherit from it.
 export type BaseLocationHook = (
   ...args: any[]
 ) => [Path, (path: Path, ...args: any[]) => any];
+
+export type BaseSearchHook = (...args: any[]) => SearchString;
 
 /*
  * Utility types that operate on hook

--- a/packages/wouter-preact/types/router.d.ts
+++ b/packages/wouter-preact/types/router.d.ts
@@ -1,22 +1,31 @@
-import { Path, BaseLocationHook } from "./location-hook";
+import {
+  Path,
+  SearchString,
+  BaseLocationHook,
+  BaseSearchHook,
+} from "./location-hook";
 
 export type Parser = (route: Path) => { pattern: RegExp; keys: string[] };
 
 // the object returned from `useRouter`
 export interface RouterObject {
   readonly hook: BaseLocationHook;
+  readonly searchHook: BaseSearchHook;
   readonly base: Path;
   readonly ownBase: Path;
   readonly parser: Parser;
   readonly parent?: RouterObject;
   readonly ssrPath?: Path;
+  readonly ssrSearch?: SearchString;
 }
 
 // basic options to construct a router
 export type RouterOptions = {
   hook?: BaseLocationHook;
+  searchHook?: BaseSearchHook;
   base?: Path;
   parser?: Parser;
   parent?: RouterObject;
   ssrPath?: Path;
+  ssrSearch?: SearchString;
 };

--- a/packages/wouter-preact/types/use-browser-location.d.ts
+++ b/packages/wouter-preact/types/use-browser-location.d.ts
@@ -1,4 +1,4 @@
-import { Path } from "./location-hook";
+import { Path, SearchString } from "./location-hook";
 
 type Primitive = string | number | bigint | boolean | null | undefined | symbol;
 export const useLocationProperty: <S extends Primitive>(
@@ -6,10 +6,11 @@ export const useLocationProperty: <S extends Primitive>(
   ssrFn?: () => S
 ) => S;
 
-type SearchString = string;
-export const useSearch: (options?: {
+export type BrowserSearchHook = (options?: {
   ssrSearch?: SearchString;
 }) => SearchString;
+
+export const useSearch: BrowserSearchHook;
 
 export const usePathname: (options?: { ssrPath?: Path }) => Path;
 

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -1,6 +1,9 @@
 import { parse as parsePattern } from "regexparam";
 
-import { useBrowserLocation } from "./use-browser-location.js";
+import {
+  useBrowserLocation,
+  useSearch as useBrowserSearch,
+} from "./use-browser-location.js";
 
 import {
   useRef,
@@ -26,10 +29,12 @@ import { absolutePath, relativePath } from "./paths.js";
 
 const defaultRouter = {
   hook: useBrowserLocation,
+  searchHook: useBrowserSearch,
   parser: parsePattern,
   base: "",
   // this option is used to override the current location during SSR
   ssrPath: undefined,
+  ssrSearch: undefined,
 };
 
 const RouterCtx = createContext(defaultRouter);
@@ -65,6 +70,11 @@ const useLocationFromRouter = (router) => {
 };
 
 export const useLocation = () => useLocationFromRouter(useRouter());
+
+export const useSearch = () => {
+  const router = useRouter();
+  return router.searchHook(router);
+};
 
 const matchRoute = (parser, route, path, loose) => {
   // falsy patterns mean this route "always matches"

--- a/packages/wouter/test/ssr.test.tsx
+++ b/packages/wouter/test/ssr.test.tsx
@@ -4,10 +4,18 @@
 
 import { it, expect, describe } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import { Route, Router, useRoute, Link, Redirect } from "wouter";
+import {
+  Route,
+  Router,
+  useRoute,
+  Link,
+  Redirect,
+  useSearch,
+  useLocation,
+} from "wouter";
 
 describe("server-side rendering", () => {
-  it("works via staticHistory", () => {
+  it("works via `ssrPath` prop", () => {
     const App = () => (
       <Router ssrPath="/users/baz">
         <Route path="/users/baz">foo</Route>
@@ -63,5 +71,40 @@ describe("server-side rendering", () => {
 
     const rendered = renderToStaticMarkup(<App />);
     expect(rendered).toBe("");
+  });
+
+  describe("rendering with given search string", () => {
+    it("is empty when not specified", () => {
+      const PrintSearch = () => <>{useSearch()}</>;
+
+      const rendered = renderToStaticMarkup(
+        <Router ssrPath="/">
+          <PrintSearch />
+        </Router>
+      );
+
+      expect(rendered).toBe("");
+    });
+
+    it("allows to override search string", () => {
+      const App = () => {
+        const search = useSearch();
+        const [location] = useLocation();
+
+        return (
+          <>
+            {location} filter by {search}
+          </>
+        );
+      };
+
+      const rendered = renderToStaticMarkup(
+        <Router ssrPath="/catalog" ssrSearch="sort=created_at">
+          <App />
+        </Router>
+      );
+
+      expect(rendered).toBe("/catalog filter by sort=created_at");
+    });
   });
 });

--- a/packages/wouter/test/use-search.test.tsx
+++ b/packages/wouter/test/use-search.test.tsx
@@ -10,7 +10,7 @@ it("returns browser search string", () => {
 });
 
 it("can be customized in the Router", () => {
-  const customSearchHook = () => "none";
+  const customSearchHook = ({ customOption = "unused" }) => "none";
 
   const { result } = renderHook(() => useSearch(), {
     wrapper: (props) => {

--- a/packages/wouter/test/use-search.test.tsx
+++ b/packages/wouter/test/use-search.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook } from "@testing-library/react";
+import { useSearch, Router } from "wouter";
+import { it, expect } from "vitest";
+
+it("returns browser search string", () => {
+  history.replaceState(null, "", "/users?active=true");
+  const { result } = renderHook(() => useSearch());
+
+  expect(result.current).toEqual("active=true");
+});
+
+it("can be customized in the Router", () => {
+  const customSearchHook = () => "none";
+
+  const { result } = renderHook(() => useSearch(), {
+    wrapper: (props) => {
+      return <Router searchHook={customSearchHook}>{props.children}</Router>;
+    },
+  });
+
+  expect(result.current).toEqual("none");
+});

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -18,8 +18,9 @@ import {
   BaseLocationHook,
   HookReturnValue,
   HookNavigationOptions,
+  BaseSearchHook,
 } from "./location-hook";
-import { BrowserLocationHook } from "./use-browser-location";
+import { BrowserLocationHook, BrowserSearchHook } from "./use-browser-location";
 
 import { RouterObject, RouterOptions } from "./router";
 
@@ -153,6 +154,10 @@ export function useRoute<
 export function useLocation<
   H extends BaseLocationHook = BrowserLocationHook
 >(): HookReturnValue<H>;
+
+export function useSearch<
+  H extends BaseSearchHook = BrowserSearchHook
+>(): ReturnType<H>;
 
 export function useParams<T = undefined>(): T extends string
   ? RouteParams<T>

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -25,7 +25,7 @@ import { BrowserLocationHook, BrowserSearchHook } from "./use-browser-location";
 import { RouterObject, RouterOptions } from "./router";
 
 // re-export some types from these modules
-export { Path, BaseLocationHook } from "./location-hook";
+export { Path, BaseLocationHook, BaseSearchHook } from "./location-hook";
 export * from "./router";
 
 import { RouteParams } from "regexparam";

--- a/packages/wouter/types/location-hook.d.ts
+++ b/packages/wouter/types/location-hook.d.ts
@@ -4,11 +4,15 @@
 
 export type Path = string;
 
+export type SearchString = string;
+
 // the base useLocation hook type. Any custom hook (including the
 // default one) should inherit from it.
 export type BaseLocationHook = (
   ...args: any[]
 ) => [Path, (path: Path, ...args: any[]) => any];
+
+export type BaseSearchHook = (...args: any[]) => SearchString;
 
 /*
  * Utility types that operate on hook

--- a/packages/wouter/types/router.d.ts
+++ b/packages/wouter/types/router.d.ts
@@ -1,20 +1,29 @@
-import { Path, BaseLocationHook } from "./location-hook";
+import {
+  Path,
+  SearchString,
+  BaseLocationHook,
+  BaseSearchHook,
+} from "./location-hook";
 
 export type Parser = (route: Path) => { pattern: RegExp; keys: string[] };
 
 // the object returned from `useRouter`
 export interface RouterObject {
   readonly hook: BaseLocationHook;
+  readonly searchHook: BaseSearchHook;
   readonly base: Path;
   readonly ownBase: Path;
   readonly parser: Parser;
   readonly ssrPath?: Path;
+  readonly ssrSearch?: SearchString;
 }
 
 // basic options to construct a router
 export type RouterOptions = {
   hook?: BaseLocationHook;
+  searchHook?: BaseSearchHook;
   base?: Path;
   parser?: Parser;
   ssrPath?: Path;
+  ssrSearch?: SearchString;
 };

--- a/packages/wouter/types/use-browser-location.d.ts
+++ b/packages/wouter/types/use-browser-location.d.ts
@@ -1,4 +1,4 @@
-import { Path } from "./location-hook";
+import { Path, SearchString } from "./location-hook";
 
 type Primitive = string | number | bigint | boolean | null | undefined | symbol;
 export const useLocationProperty: <S extends Primitive>(
@@ -6,10 +6,11 @@ export const useLocationProperty: <S extends Primitive>(
   ssrFn?: () => S
 ) => S;
 
-type SearchString = string;
-export const useSearch: (options?: {
+export type BrowserSearchHook = (options?: {
   ssrSearch?: SearchString;
 }) => SearchString;
+
+export const useSearch: BrowserSearchHook;
 
 export const usePathname: (options?: { ssrPath?: Path }) => Path;
 


### PR DESCRIPTION
This PR makes it possible to import `useSearch` directly from `"wouter"`. By default, it is the same as browser search hook from `"use-browser-location"`, however it can be customized via `<Router searchHook={custom} />`