### PR TITLE
v3: link with as child pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^3.7.4",
     "size-limit": "^10.0.1",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "vitest": "^0.34.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-replace": "^5.0.2",
     "@size-limit/preset-small-lib": "^10.0.1",
+    "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^14.0.0",
     "@types/babel__core": "^7.20.2",
     "@types/react": "^18.2.0",
@@ -158,6 +159,6 @@
     "rollup": "^3.7.4",
     "size-limit": "^10.0.1",
     "typescript": "5.0.4",
-    "vitest": "^0.34.3"
+    "vitest": "^0.34.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     },
     {
       "path": "packages/wouter-preact/esm/index.js",
-      "limit": "2000 B",
+      "limit": "2500 B",
       "ignore": [
         "preact",
         "preact/hooks"

--- a/packages/wouter-preact/test/preact.test.tsx
+++ b/packages/wouter-preact/test/preact.test.tsx
@@ -24,7 +24,8 @@ describe("Preact support", () => {
           <Link href="/albums/all" onClick={fn} data-testid="index-link">
             The Best Albums Ever
           </Link>
-          <Link to="/albums/london-calling">
+          {/* @ts-ignore */}
+          <Link to="/albums/london-calling" asChild>
             <a data-testid="featured-link">
               Featured Now: London Calling, Clash
             </a>

--- a/packages/wouter-preact/test/preact.test.tsx
+++ b/packages/wouter-preact/test/preact.test.tsx
@@ -24,7 +24,6 @@ describe("Preact support", () => {
           <Link href="/albums/all" onClick={fn} data-testid="index-link">
             The Best Albums Ever
           </Link>
-          {/* @ts-ignore */}
           <Link to="/albums/london-calling" asChild>
             <a data-testid="featured-link">
               Featured Now: London Calling, Clash

--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -81,9 +81,9 @@ export type NavigationalProps<
 > = ({ to: Path; href?: never } | { href: Path; to?: never }) &
   HookNavigationOptions<H>;
 
-type AsChildProps<RequiredProps, DefaultElementProps> =
-  | ({ asChild?: false } & RequiredProps & DefaultElementProps)
-  | ({ asChild: true; children: ComponentChildren } & RequiredProps);
+type AsChildProps<ComponentProps, DefaultElementProps> =
+  | ({ asChild?: false } & ComponentProps & DefaultElementProps)
+  | ({ asChild: true; children: ComponentChildren } & ComponentProps);
 
 export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> =
   AsChildProps<NavigationalProps<H>, JSX.HTMLAttributes>;

--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -81,11 +81,12 @@ export type NavigationalProps<
 > = ({ to: Path; href?: never } | { href: Path; to?: never }) &
   HookNavigationOptions<H>;
 
-export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> = Omit<
-  JSX.HTMLAttributes,
-  "href"
-> &
-  NavigationalProps<H>;
+type AsChildProps<RequiredProps, DefaultElementProps> =
+  | ({ asChild?: false } & RequiredProps & DefaultElementProps)
+  | ({ asChild: true; children: ComponentChildren } & RequiredProps);
+
+export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> =
+  AsChildProps<NavigationalProps<H>, JSX.HTMLAttributes>;
 
 export type RedirectProps<H extends BaseLocationHook = BrowserLocationHook> =
   NavigationalProps<H> & {

--- a/packages/wouter/setup-vitest.ts
+++ b/packages/wouter/setup-vitest.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -189,8 +189,10 @@ export const Link = forwardRef((props, ref) => {
     onClick: _onClick,
     asChild,
     children,
+    /* eslint-disable no-unused-vars */
     replace /* ignore nav props */,
     state /* ignore nav props */,
+    /* eslint-enable no-unused-vars */
     ...restProps
   } = props;
 

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -215,7 +215,15 @@ export const Link = forwardRef((props, ref) => {
     });
   }
 
-  return h("a", { ...props, href: link, onClick: handleClick, to: null, ref });
+  return h("a", {
+    ...props,
+    href: link,
+    onClick: handleClick,
+    to: null,
+    replace: null,
+    state: null,
+    ref,
+  });
 });
 
 const flattenChildren = (children) => {

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -204,12 +204,15 @@ export const Link = forwardRef((props, ref) => {
     }
   });
 
+  // handle nested routers and absolute paths
   const link = href[0] === "~" ? href.slice(1) : router.base + href;
 
   if (asChild) {
-    const jsx = isValidElement(children) ? children : null;
-    return cloneElement(jsx, {
-      // handle nested routers and absolute paths
+    if (!isValidElement(children)) {
+      throw Error("Only one child allowed");
+    }
+
+    return cloneElement(children, {
       href: link,
       onClick: handleClick,
     });

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -183,7 +183,7 @@ export const Link = forwardRef((props, ref) => {
   const router = useRouter();
   const [, navigate] = useLocationFromRouter(router);
 
-  const { to, href = to, children, onClick } = props;
+  const { to, href = to, children, asChild, onClick } = props;
 
   const handleClick = useEvent((event) => {
     // ignores the navigation when clicked using right mouse button or
@@ -204,17 +204,18 @@ export const Link = forwardRef((props, ref) => {
     }
   });
 
-  // wraps children in `a` if needed
-  const extraProps = {
-    // handle nested routers and absolute paths
-    href: href[0] === "~" ? href.slice(1) : router.base + href,
-    onClick: handleClick,
-    to: null,
-    ref,
-  };
-  const jsx = isValidElement(children) ? children : h("a", props);
+  const link = href[0] === "~" ? href.slice(1) : router.base + href;
 
-  return cloneElement(jsx, extraProps);
+  if (asChild) {
+    const jsx = isValidElement(children) ? children : null;
+    return cloneElement(jsx, {
+      // handle nested routers and absolute paths
+      href: link,
+      onClick: handleClick,
+    });
+  }
+
+  return h("a", { ...props, href: link, onClick: handleClick, to: null, ref });
 });
 
 const flattenChildren = (children) => {

--- a/packages/wouter/test/link.test-d.tsx
+++ b/packages/wouter/test/link.test-d.tsx
@@ -1,44 +1,60 @@
-import { describe, it, assertType } from "vitest";
+import { describe, it } from "vitest";
 import { Link } from "wouter";
 import * as React from "react";
 
-describe("Link types", () => {
+describe("<Link /> types", () => {
   it("should have required prop href", () => {
     // @ts-expect-error
-    assertType(<Link>test</Link>);
-    assertType(<Link href="/">test</Link>);
+    <Link>test</Link>;
+    <Link href="/">test</Link>;
   });
 
-  it("should support state prop", () => {
-    assertType(
-      <Link href="/" state={{ a: "foo" }}>
-        test
-      </Link>
-    );
-    assertType(
-      <Link href="/" state={null}>
-        test
-      </Link>
-    );
-    assertType(
-      <Link href="/" state={undefined}>
-        test
-      </Link>
-    );
-    assertType(
-      <Link href="/" state="string">
-        test
-      </Link>
-    );
+  it("should throw error when `to` and `href` props are used in same time", () => {
+    // @ts-expect-error
+    <Link to="/hello" href="/world">
+      Hello
+    </Link>;
+  });
+
+  it("should inherit props from `HTMLAnchorElements`", () => {
+    <Link to="/hello" className="hello">
+      Hello
+    </Link>;
+
+    <Link to="/hello" style={{}}>
+      Hello
+    </Link>;
+
+    <Link to="/hello" target="_blank">
+      Hello
+    </Link>;
+
+    <Link to="/hello" download ping="he-he">
+      Hello
+    </Link>;
+  });
+
+  it("should support other navigation params", () => {
+    <Link href="/" state={{ a: "foo" }}>
+      test
+    </Link>;
+
+    <Link href="/" replace>
+      test
+    </Link>;
+
+    <Link href="/" state={undefined}>
+      test
+    </Link>;
   });
 });
 
-describe("Link's ref", () => {
+describe("<Link /> with ref", () => {
   it("should work", () => {
     const ref = React.useRef<HTMLAnchorElement>(null);
 
     <Link to="/" ref={ref}>
-      HELLO
+      Hello
     </Link>;
   });
 
@@ -47,7 +63,7 @@ describe("Link's ref", () => {
 
     // @ts-expect-error
     <Link to="/" ref={ref}>
-      HELLO
+      Hello
     </Link>;
   });
 
@@ -56,19 +72,61 @@ describe("Link's ref", () => {
 
     // @ts-expect-error
     <Link to="/" ref={ref}>
-      HELLO
-    </Link>;
-  });
-
-  it("should work with composed components", () => {
-    const ref = React.useRef<React.ElementRef<typeof Component>>(null);
-
-    <Link to="/">
-      <Component ref={ref}></Component>
+      Hello
     </Link>;
   });
 });
 
-const Component = React.forwardRef<{ hello: "world" }>((props, ref) => {
-  return <>test</>;
+describe("<Link /> in asChild mode", () => {
+  it("should work", () => {
+    <Link to="/" asChild>
+      <a>Hello</a>
+    </Link>;
+  });
+
+  it("should throw error when `to` and `href` props are used in same time", () => {
+    // @ts-expect-error
+    <Link to="/hello" href="/world" asChild>
+      <a>Hello</a>
+    </Link>;
+  });
+
+  it("should throw error when unsupported props are provided", () => {
+    // @ts-expect-error
+    <Link to="/" asChild className="">
+      <a>Hello</a>
+    </Link>;
+
+    // @ts-expect-error
+    <Link to="/" asChild style={{}}>
+      <a>Hello</a>
+    </Link>;
+
+    // @ts-expect-error
+    <Link to="/" asChild unknown={10}>
+      <a>Hello</a>
+    </Link>;
+
+    // @ts-expect-error
+    <Link to="/" asChild ref={null}>
+      <a>Hello</a>
+    </Link>;
+  });
+
+  it("should throw error when to and href props are used in same time", () => {
+    // @ts-expect-error
+    <Link to="/hello" href="/world" asChild>
+      <a>Hello</a>
+    </Link>;
+  });
+
+  it("should support other navigation params", () => {
+    <Link to="/" asChild replace>
+      <a>Hello</a>
+    </Link>;
+
+    <Link to="/" asChild state={{ hello: "world" }}>
+      <a>Hello</a>
+    </Link>;
+  });
 });

--- a/packages/wouter/test/link.test-d.tsx
+++ b/packages/wouter/test/link.test-d.tsx
@@ -1,6 +1,11 @@
 import { describe, it } from "vitest";
-import { Link } from "wouter";
+import { Link, type Path } from "wouter";
 import * as React from "react";
+
+type NetworkLocationHook = () => [
+  Path,
+  (path: string, options: { host: string; retries?: number }) => void
+];
 
 describe("<Link /> types", () => {
   it("should have required prop href", () => {
@@ -49,6 +54,19 @@ describe("<Link /> types", () => {
     </Link>;
 
     <Link href="/" state={undefined}>
+      test
+    </Link>;
+  });
+
+  it("should work with generic type", () => {
+    <Link<NetworkLocationHook> href="/" host="wouter.com">
+      test
+    </Link>;
+
+    // @ts-expect-error
+    <Link<NetworkLocationHook> href="/">test</Link>;
+
+    <Link<NetworkLocationHook> href="/" host="wouter.com" retries={4}>
       test
     </Link>;
   });
@@ -130,6 +148,21 @@ describe("<Link /> with `asChild` prop", () => {
 
     <Link to="/" asChild state={{ hello: "world" }}>
       <a>Hello</a>
+    </Link>;
+  });
+
+  it("should work with generic type", () => {
+    <Link<NetworkLocationHook> asChild to="/" host="wouter.com">
+      <div>test</div>
+    </Link>;
+
+    // @ts-expect-error
+    <Link<NetworkLocationHook> asChild to="/">
+      <div>test</div>
+    </Link>;
+
+    <Link<NetworkLocationHook> asChild to="/" host="wouter.com" retries={4}>
+      <div>test</div>
     </Link>;
   });
 });

--- a/packages/wouter/test/link.test-d.tsx
+++ b/packages/wouter/test/link.test-d.tsx
@@ -9,7 +9,7 @@ describe("<Link /> types", () => {
     <Link href="/">test</Link>;
   });
 
-  it("should throw error when `to` and `href` props are used in same time", () => {
+  it("does not allow `to` and `href` props to be used at the same time", () => {
     // @ts-expect-error
     <Link to="/hello" href="/world">
       Hello

--- a/packages/wouter/test/link.test-d.tsx
+++ b/packages/wouter/test/link.test-d.tsx
@@ -16,7 +16,7 @@ describe("<Link /> types", () => {
     </Link>;
   });
 
-  it("should inherit props from `HTMLAnchorElements`", () => {
+  it("should inherit props from `HTMLAnchorElement`", () => {
     <Link to="/hello" className="hello">
       Hello
     </Link>;

--- a/packages/wouter/test/link.test-d.tsx
+++ b/packages/wouter/test/link.test-d.tsx
@@ -43,6 +43,11 @@ describe("<Link /> types", () => {
       test
     </Link>;
 
+    // @ts-expect-error
+    <Link to="/" replace={{ nope: 1 }}>
+      Hello
+    </Link>;
+
     <Link href="/" state={undefined}>
       test
     </Link>;
@@ -77,21 +82,21 @@ describe("<Link /> with ref", () => {
   });
 });
 
-describe("<Link /> in asChild mode", () => {
+describe("<Link /> with `asChild` prop", () => {
   it("should work", () => {
     <Link to="/" asChild>
       <a>Hello</a>
     </Link>;
   });
 
-  it("should throw error when `to` and `href` props are used in same time", () => {
+  it("does not allow `to` and `href` props to be used at the same time", () => {
     // @ts-expect-error
     <Link to="/hello" href="/world" asChild>
       <a>Hello</a>
     </Link>;
   });
 
-  it("should throw error when unsupported props are provided", () => {
+  it("does not allow other props", () => {
     // @ts-expect-error
     <Link to="/" asChild className="">
       <a>Hello</a>
@@ -113,15 +118,13 @@ describe("<Link /> in asChild mode", () => {
     </Link>;
   });
 
-  it("should throw error when to and href props are used in same time", () => {
-    // @ts-expect-error
-    <Link to="/hello" href="/world" asChild>
-      <a>Hello</a>
-    </Link>;
-  });
-
   it("should support other navigation params", () => {
     <Link to="/" asChild replace>
+      <a>Hello</a>
+    </Link>;
+
+    // @ts-expect-error
+    <Link to="/" asChild replace={12}>
       <a>Hello</a>
     </Link>;
 

--- a/packages/wouter/test/link.test.tsx
+++ b/packages/wouter/test/link.test.tsx
@@ -167,7 +167,7 @@ describe("<Link />", () => {
 });
 
 describe("<Link /> with `asChild` prop", () => {
-  it("works for any other elements as well", () => {
+  it("when `asChild` is not specified, wraps the children in an <a />", () => {
     const { getByText } = render(
       <Link href="/about">
         <div className="link--wannabe">Click Me</div>

--- a/packages/wouter/test/link.test.tsx
+++ b/packages/wouter/test/link.test.tsx
@@ -1,206 +1,170 @@
 import { useRef, useEffect, PropsWithChildren, MouseEventHandler } from "react";
-import { it, expect, afterEach, vi } from "vitest";
+import { it, expect, afterEach, vi, describe } from "vitest";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 
 import { Router, Link } from "wouter";
 
-const LinkWithForwardedRef = (props: PropsWithChildren<{}>) => {
-  const ref = useRef<HTMLAnchorElement>(null);
-
-  useEffect(() => {
-    if (ref.current) {
-      ref.current.innerHTML = "Tested";
-    }
-  }, [ref]);
-
-  return (
-    <Link href="/about" ref={ref}>
-      {props.children}
-    </Link>
-  );
-};
-
 afterEach(cleanup);
 
-it("renders a link with proper attributes", () => {
-  const { container } = render(
-    <Link href="/about">
-      <a className="link--active">Click Me</a>
-    </Link>
-  );
+describe("base link", () => {
+  it("renders a link with proper attributes", () => {
+    const { getByText } = render(
+      <Link href="/about" className="link--active">
+        Click Me
+      </Link>
+    );
 
-  const link = container.firstChild as HTMLAnchorElement;
+    const element = getByText("Click Me");
 
-  expect(link.tagName).toBe("A");
-  expect(link.className).toBe("link--active");
-  expect(link.getAttribute("href")).toBe("/about");
-  expect(link.textContent).toBe("Click Me");
-});
-
-it("wraps children in an <a /> if needed", () => {
-  const { container } = render(<Link href="/about">Testing</Link>);
-  const link = container.firstChild as HTMLAnchorElement;
-
-  expect(link.tagName).toBe("A");
-  expect(link.textContent).toBe("Testing");
-});
-
-it("works for any other elements as well", () => {
-  const { container } = render(
-    <Link href="/about">
-      <div className="link--wannabe">Click Me</div>
-    </Link>
-  );
-
-  const link = container.firstChild as HTMLElement;
-
-  expect(link.tagName).toBe("DIV");
-  expect(link.className).toBe("link--wannabe");
-  expect(link.textContent).toBe("Click Me");
-});
-
-it("passes ref to <a />", () => {
-  const { container } = render(
-    <LinkWithForwardedRef>Testing</LinkWithForwardedRef>
-  );
-  const link = container.firstChild as HTMLAnchorElement;
-
-  expect(link.tagName).toBe("A");
-  expect(link.textContent).toBe("Tested");
-});
-
-it("passes ref to any other child element", () => {
-  const { container } = render(
-    <LinkWithForwardedRef>
-      <div>Testing</div>
-    </LinkWithForwardedRef>
-  );
-  const link = container.firstChild as HTMLElement;
-
-  expect(link.tagName).toBe("DIV");
-  expect(link.textContent).toBe("Tested");
-});
-
-it("still creates a plain link when nothing is passed", () => {
-  const { container } = render(<Link href="/about" />);
-  const link = container.firstChild as HTMLAnchorElement;
-
-  expect(link.tagName).toBe("A");
-  expect(link.getAttribute("href")).toBe("/about");
-});
-
-it("supports `to` prop as an alias to `href`", () => {
-  const { container } = render(<Link to="/about">Hello</Link>);
-  const link = container.firstChild as HTMLAnchorElement;
-
-  expect(link.getAttribute("href")).toBe("/about");
-});
-
-it("performs a navigation when the link is clicked", () => {
-  const { getByTestId } = render(
-    <Link href="/goo-baz">
-      <a data-testid="link" />
-    </Link>
-  );
-  fireEvent.click(getByTestId("link"));
-  expect(location.pathname).toBe("/goo-baz");
-});
-
-it("supports replace navigation", () => {
-  const { getByTestId } = render(
-    <Link href="/goo-baz" replace>
-      <a data-testid="link" />
-    </Link>
-  );
-
-  const histBefore = history.length;
-
-  fireEvent.click(getByTestId("link"));
-  expect(location.pathname).toBe("/goo-baz");
-  expect(history.length).toBe(histBefore);
-});
-
-it("ignores the navigation when clicked with modifiers", () => {
-  const { getByTestId } = render(
-    <Link href="/users" data-testid="link">
-      click
-    </Link>
-  );
-  const clickEvt = new MouseEvent("click", {
-    bubbles: true,
-    cancelable: true,
-    button: 0,
-    ctrlKey: true,
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveAttribute("href", "/about");
+    expect(element).toHaveClass("link--active");
   });
 
-  // js-dom doesn't implement browser navigation (e.g. changing location
-  // when a link is clicked) so we need just ingore it to avoid warnings
-  clickEvt.preventDefault();
+  it("passes ref to <a />", () => {
+    const refCallback = vi.fn<[HTMLAnchorElement], void>();
+    const { getByText } = render(
+      <Link href="/" ref={refCallback}>
+        Testing
+      </Link>
+    );
 
-  fireEvent(getByTestId("link"), clickEvt);
-  expect(location.pathname).not.toBe("/users");
+    const element = getByText("Testing");
+
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveAttribute("href", "/");
+
+    expect(refCallback).toBeCalledTimes(1);
+    expect(refCallback).toBeCalledWith(element);
+  });
+
+  it("still creates a plain link when nothing is passed", () => {
+    const { getByTestId } = render(<Link href="/about" data-testid="link" />);
+
+    const element = getByTestId("link");
+
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveAttribute("href", "/about");
+    expect(element).toBeEmptyDOMElement();
+  });
+
+  it("supports `to` prop as an alias to `href`", () => {
+    const { getByText } = render(<Link to="/about">Hello</Link>);
+    const element = getByText("Hello");
+
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveAttribute("href", "/about");
+  });
+
+  it("performs a navigation when the link is clicked", () => {
+    const { getByTestId } = render(
+      <Link href="/goo-baz" data-testid="link">
+        link
+      </Link>
+    );
+
+    fireEvent.click(getByTestId("link"));
+
+    expect(location.pathname).toBe("/goo-baz");
+  });
+
+  it("supports replace navigation", () => {
+    const { getByTestId } = render(
+      <Link href="/goo-baz" replace data-testid="link">
+        link
+      </Link>
+    );
+
+    const histBefore = history.length;
+
+    fireEvent.click(getByTestId("link"));
+
+    expect(location.pathname).toBe("/goo-baz");
+    expect(history.length).toBe(histBefore);
+  });
+
+  it("ignores the navigation when clicked with modifiers", () => {
+    const { getByTestId } = render(
+      <Link href="/users" data-testid="link">
+        click
+      </Link>
+    );
+    const clickEvt = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      ctrlKey: true,
+    });
+
+    // js-dom doesn't implement browser navigation (e.g. changing location
+    // when a link is clicked) so we need just ingore it to avoid warnings
+    clickEvt.preventDefault();
+
+    fireEvent(getByTestId("link"), clickEvt);
+    expect(location.pathname).not.toBe("/users");
+  });
+
+  it("ignores the navigation when event is cancelled", () => {
+    const clickHandler: MouseEventHandler = (e) => {
+      e.preventDefault();
+    };
+
+    const { getByTestId } = render(
+      <Link href="/users" data-testid="link" onClick={clickHandler}>
+        click
+      </Link>
+    );
+
+    fireEvent.click(getByTestId("link"));
+    expect(location.pathname).not.toBe("/users");
+  });
+
+  it("accepts an `onClick` prop, fired before the navigation", () => {
+    const clickHandler = vi.fn();
+
+    const { getByTestId } = render(
+      <Link href="/" onClick={clickHandler}>
+        <a data-testid="link" />
+      </Link>
+    );
+
+    fireEvent.click(getByTestId("link"));
+    expect(clickHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders `href` with basepath", () => {
+    const { getByTestId } = render(
+      <Router base="/app">
+        <Link href="/dashboard" data-testid="link" />
+      </Router>
+    );
+
+    const link = getByTestId("link");
+    expect(link.getAttribute("href")).toBe("/app/dashboard");
+  });
+
+  it("renders `href` with absolute links", () => {
+    const { getByTestId } = render(
+      <Router base="/app">
+        <Link href="~/home" data-testid="link" />
+      </Router>
+    );
+
+    const element = getByTestId("link");
+    expect(element).toHaveAttribute("href", "/home");
+  });
+
+  it("supports history state", () => {
+    const testState = { hello: "world" };
+    const { getByTestId } = render(
+      <Link href="/goo-baz" state={testState} data-testid="link">
+        link
+      </Link>
+    );
+
+    fireEvent.click(getByTestId("link"));
+    expect(location.pathname).toBe("/goo-baz");
+    expect(history.state).toBe(testState);
+  });
 });
 
-it("ignores the navigation when event is cancelled", () => {
-  const clickHandler: MouseEventHandler = (e) => {
-    e.preventDefault();
-  };
-
-  const { getByTestId } = render(
-    <Link href="/users" data-testid="link" onClick={clickHandler}>
-      click
-    </Link>
-  );
-
-  fireEvent.click(getByTestId("link"));
-  expect(location.pathname).not.toBe("/users");
-});
-
-it("accepts an `onClick` prop, fired before the navigation", () => {
-  const clickHandler = vi.fn();
-
-  const { getByTestId } = render(
-    <Link href="/" onClick={clickHandler}>
-      <a data-testid="link" />
-    </Link>
-  );
-
-  fireEvent.click(getByTestId("link"));
-  expect(clickHandler).toHaveBeenCalledTimes(1);
-});
-
-it("renders `href` with basepath", () => {
-  const { getByTestId } = render(
-    <Router base="/app">
-      <Link href="/dashboard" data-testid="link" />
-    </Router>
-  );
-
-  const link = getByTestId("link");
-  expect(link.getAttribute("href")).toBe("/app/dashboard");
-});
-
-it("renders `href` with absolute links", () => {
-  const { getByTestId } = render(
-    <Router base="/app">
-      <Link href="~/home" data-testid="link" />
-    </Router>
-  );
-
-  const link = getByTestId("link");
-  expect(link.getAttribute("href")).toBe("/home");
-});
-
-it("supports history state", () => {
-  const testState = { hello: "world" };
-  const { getByTestId, unmount } = render(
-    <Link href="/goo-baz" state={testState}>
-      <a data-testid="link" />
-    </Link>
-  );
-
-  fireEvent.click(getByTestId("link"));
-  expect(location.pathname).toBe("/goo-baz");
-  expect(history.state).toBe(testState);
-  unmount();
-});

--- a/packages/wouter/test/link.test.tsx
+++ b/packages/wouter/test/link.test.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, PropsWithChildren, MouseEventHandler } from "react";
+import { type MouseEventHandler } from "react";
 import { it, expect, afterEach, vi, describe } from "vitest";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 
@@ -6,7 +6,7 @@ import { Router, Link } from "wouter";
 
 afterEach(cleanup);
 
-describe("base link", () => {
+describe("<Link />", () => {
   it("renders a link with proper attributes", () => {
     const { getByText } = render(
       <Link href="/about" className="link--active">
@@ -163,5 +163,37 @@ describe("base link", () => {
     fireEvent.click(getByTestId("link"));
     expect(location.pathname).toBe("/goo-baz");
     expect(history.state).toBe(testState);
+  });
+});
+
+describe("<Link /> in asChild mode", () => {
+  it("works for any other elements as well", () => {
+    const { getByText } = render(
+      <Link href="/about">
+        <div className="link--wannabe">Click Me</div>
+      </Link>
+    );
+
+    const link = getByText("Click Me");
+
+    expect(link.tagName).toBe("DIV");
+    expect(link).not.toHaveAttribute("href");
+    expect(link).toHaveClass("link--wannabe");
+    expect(link).toHaveTextContent("Click Me");
+  });
+
+  it("injects href prop when rendered with `asChild`", () => {
+    const { getByText } = render(
+      <Link href="/about" asChild>
+        <div className="link--wannabe">Click Me</div>
+      </Link>
+    );
+
+    const link = getByText("Click Me");
+
+    expect(link.tagName).toBe("DIV");
+    expect(link).toHaveClass("link--wannabe");
+    expect(link).toHaveAttribute("href", "/about");
+    expect(link).toHaveTextContent("Click Me");
   });
 });

--- a/packages/wouter/test/link.test.tsx
+++ b/packages/wouter/test/link.test.tsx
@@ -180,28 +180,40 @@ describe("<Link /> with `asChild` prop", () => {
     expect(link).not.toHaveAttribute("href");
     expect(link).toHaveClass("link--wannabe");
     expect(link).toHaveTextContent("Click Me");
+
+    expect(link.parentElement?.tagName).toBe("A");
+    expect(link.parentElement).toHaveAttribute("href", "/about");
   });
 
-  it("throws error when invalid element is provided", () => {
-    expect(() =>
-      render(
-        <Link href="/about" asChild>
-          Click Me
-        </Link>
-      )
-    ).throw();
+  it("when invalid element is provided, wraps the children in an <a />", () => {
+    const { getByText } = render(
+      <Link href="/about" asChild>
+        Click Me
+      </Link>
+    );
+
+    const link = getByText("Click Me");
+
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("href", "/about");
+    expect(link).toHaveTextContent("Click Me");
   });
 
-  it("throws error when more than one element is provided", () => {
-    expect(() =>
-      render(
-        <Link href="/about" asChild>
-          <span>1</span>
-          <span>2</span>
-          <span>3</span>
-        </Link>
-      )
-    ).throw();
+  it("when more than one element is provided, wraps the children in an <a />", async () => {
+    const { getByText } = render(
+      <Link href="/about" asChild>
+        <span>1</span>
+        <span>2</span>
+        <span>3</span>
+      </Link>
+    );
+
+    const span = getByText("1");
+
+    expect(span.parentElement?.tagName).toBe("A");
+
+    expect(span.parentElement).toHaveAttribute("href", "/about");
+    expect(span.parentElement).toHaveTextContent("123");
   });
 
   it("injects href prop when rendered with `asChild`", () => {

--- a/packages/wouter/test/link.test.tsx
+++ b/packages/wouter/test/link.test.tsx
@@ -167,4 +167,3 @@ describe("base link", () => {
     expect(history.state).toBe(testState);
   });
 });
-

--- a/packages/wouter/test/link.test.tsx
+++ b/packages/wouter/test/link.test.tsx
@@ -166,7 +166,7 @@ describe("<Link />", () => {
   });
 });
 
-describe("<Link /> in asChild mode", () => {
+describe("<Link /> with `asChild` prop", () => {
   it("works for any other elements as well", () => {
     const { getByText } = render(
       <Link href="/about">

--- a/packages/wouter/test/link.test.tsx
+++ b/packages/wouter/test/link.test.tsx
@@ -123,9 +123,7 @@ describe("base link", () => {
     const clickHandler = vi.fn();
 
     const { getByTestId } = render(
-      <Link href="/" onClick={clickHandler}>
-        <a data-testid="link" />
-      </Link>
+      <Link href="/" onClick={clickHandler} data-testid="link" />
     );
 
     fireEvent.click(getByTestId("link"));

--- a/packages/wouter/test/link.test.tsx
+++ b/packages/wouter/test/link.test.tsx
@@ -182,6 +182,28 @@ describe("<Link /> in asChild mode", () => {
     expect(link).toHaveTextContent("Click Me");
   });
 
+  it("throws error when invalid element is provided", () => {
+    expect(() =>
+      render(
+        <Link href="/about" asChild>
+          Click Me
+        </Link>
+      )
+    ).throw();
+  });
+
+  it("throws error when more than one element is provided", () => {
+    expect(() =>
+      render(
+        <Link href="/about" asChild>
+          <span>1</span>
+          <span>2</span>
+          <span>3</span>
+        </Link>
+      )
+    ).throw();
+  });
+
   it("injects href prop when rendered with `asChild`", () => {
     const { getByText } = render(
       <Link href="/about" asChild>

--- a/packages/wouter/test/ssr.test.tsx
+++ b/packages/wouter/test/ssr.test.tsx
@@ -55,7 +55,7 @@ describe("server-side rendering", () => {
     );
 
     const rendered = renderToStaticMarkup(<App />);
-    expect(rendered).toBe(`<a href="/users/1" title="Profile">Mark</a>`);
+    expect(rendered).toBe(`<a title="Profile" href="/users/1">Mark</a>`);
   });
 
   it("renders redirects however they have effect only on a client-side", () => {

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -97,11 +97,6 @@ export type NavigationalProps<
 > = ({ to: Path; href?: never } | { href: Path; to?: never }) &
   HookNavigationOptions<H>;
 
-export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> = Omit<
-  AnchorHTMLAttributes<HTMLAnchorElement>,
-  "href"
-> &
-  NavigationalProps<H>;
 
 export type RedirectProps<H extends BaseLocationHook = BrowserLocationHook> =
   NavigationalProps<H> & {
@@ -113,8 +108,17 @@ export function Redirect<H extends BaseLocationHook = BrowserLocationHook>(
   context?: any
 ): ReactElement<any, any> | null;
 
+type AsChildProps<RequiredProps, DefaultElementProps> =
+  | ({ asChild?: false } & RequiredProps & DefaultElementProps)
+  | ({ asChild: true; children: React.ReactNode } & RequiredProps);
+
+export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> = AsChildProps<
+  NavigationalProps<H>,
+  AnchorHTMLAttributes<HTMLAnchorElement> & RefAttributes<HTMLAnchorElement>
+>;
+
 export function Link<H extends BaseLocationHook = BrowserLocationHook>(
-  props: PropsWithChildren<LinkProps<H>> & RefAttributes<HTMLAnchorElement>,
+  props: LinkProps<H>,
   context?: any
 ): ReactElement<any, any> | null;
 

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -97,7 +97,6 @@ export type NavigationalProps<
 > = ({ to: Path; href?: never } | { href: Path; to?: never }) &
   HookNavigationOptions<H>;
 
-
 export type RedirectProps<H extends BaseLocationHook = BrowserLocationHook> =
   NavigationalProps<H> & {
     children?: never;
@@ -112,10 +111,11 @@ type AsChildProps<RequiredProps, DefaultElementProps> =
   | ({ asChild?: false } & RequiredProps & DefaultElementProps)
   | ({ asChild: true; children: React.ReactNode } & RequiredProps);
 
-export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> = AsChildProps<
-  NavigationalProps<H>,
-  AnchorHTMLAttributes<HTMLAnchorElement> & RefAttributes<HTMLAnchorElement>
->;
+export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> =
+  AsChildProps<
+    NavigationalProps<H>,
+    AnchorHTMLAttributes<HTMLAnchorElement> & RefAttributes<HTMLAnchorElement>
+  >;
 
 export function Link<H extends BaseLocationHook = BrowserLocationHook>(
   props: LinkProps<H>,

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -107,9 +107,9 @@ export function Redirect<H extends BaseLocationHook = BrowserLocationHook>(
   context?: any
 ): ReactElement<any, any> | null;
 
-type AsChildProps<RequiredProps, DefaultElementProps> =
-  | ({ asChild?: false } & RequiredProps & DefaultElementProps)
-  | ({ asChild: true; children: React.ReactNode } & RequiredProps);
+type AsChildProps<ComponentProps, DefaultElementProps> =
+  | ({ asChild?: false } & ComponentProps & DefaultElementProps)
+  | ({ asChild: true; children: React.ReactNode } & ComponentProps);
 
 export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> =
   AsChildProps<

--- a/packages/wouter/vitest.config.ts
+++ b/packages/wouter/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineProject({
   plugins: [react({ jsxRuntime: "automatic" })],
   test: {
     name: "wouter-react",
+    setupFiles: "./setup-vitest.ts",
     environment: "jsdom",
   },
 });


### PR DESCRIPTION
`<Link asChild />` feature

### usage

```
// right

<Link to='href' ref={ref}>
  link
</Link>

<Link to='href' ref={ref} className={'hello'}>
  link
</Link>

<Link to='href' asChild>
  <Button>hello world</Button>
</Link>

<Link to='href' asChild>
  <Button ref={ref}>hello world</Button>
</Link>

// wrong

<Link to='href' asChild ref={ref} className={'noo'}>
  <Button ref={ref}>hello world</Button>
</Link>

<Link to='href' asChild>
  text
</Link>
```