### PR TITLE
`use-hash-location` subscribes to `hashchange` once

### DIFF
--- a/packages/wouter/test/use-hash-location.test.tsx
+++ b/packages/wouter/test/use-hash-location.test.tsx
@@ -1,10 +1,12 @@
 import { it, expect, beforeEach } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { renderHook, render } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import { Router, Route, useLocation } from "wouter";
 import { useHashLocation } from "wouter/use-hash-location";
 
 import { waitForHashChangeEvent } from "./test-utils";
+import { ReactElement, useSyncExternalStore } from "react";
 
 beforeEach(() => {
   history.replaceState(null, "", "/");
@@ -120,4 +122,67 @@ it("is not sensitive to leading / or # when navigating", async () => {
   await waitForHashChangeEvent(() => navigate("#/look-ma-no-hashes"));
   expect(location.hash).toBe("#/look-ma-no-hashes");
   expect(result.current[0]).toBe("/look-ma-no-hashes");
+});
+
+it("works even if `hashchange` listeners are called asynchronously ", async () => {
+  const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  // we want `hashchange` to stop invoking listeners before it reaches the
+  // outer <Route path="/a" />. this is done to simulate a situation when
+  // `hashchange` listeners are called asynchrounously
+  //
+  // per https://github.com/whatwg/html/issues/1792
+  // some browsers fire `hashchange` and `popstate` asynchronously, so
+  // when the event listeners are called, a microtask can be scheduled in between,
+  // and we may end up with a teared state. inner components subscribe to `hashchange`
+  // earlier so they may render even though their parent route does not match
+  const subscribeToHashchange = (cb: () => void) => {
+    const fn = (event: HashChangeEvent) => {
+      event.stopImmediatePropagation();
+      cb();
+    };
+
+    window.addEventListener("hashchange", fn);
+    return () => window.removeEventListener("hashchange", fn);
+  };
+
+  const InterceptAndStopHashchange = ({
+    children,
+  }: {
+    children: ReactElement;
+  }) => {
+    useSyncExternalStore(subscribeToHashchange, () => true);
+    return children;
+  };
+
+  const paths: string[] = [];
+
+  // keep track of rendered paths
+  const LogLocations = () => {
+    paths.push(useLocation()[0]);
+    return null;
+  };
+
+  location.hash = "#/a";
+
+  const { unmount } = render(
+    <Router hook={useHashLocation}>
+      <Route path="/a">
+        <InterceptAndStopHashchange>
+          <LogLocations />
+        </InterceptAndStopHashchange>
+      </Route>
+    </Router>
+  );
+
+  location.hash = "#/b";
+
+  // wait for all `hashchange` listeners to be called
+  // can't use `waitForHashChangeEvent` here because it gets cancelled along the way
+  await nextTick();
+
+  // paths should not contain "b", because the outer route
+  // does not match, so inner component should not be rendered
+  expect(paths).toEqual(["/a"]);
+  unmount();
 });


### PR DESCRIPTION
To fix tearing issue when `hashchange` is fired asynchronously.
See this discussion https://github.com/whatwg/html/issues/1792

TLDR; React schedules micro-task in between calls to `hashchange` event listeners, because in some browsers this event is fired asynchronously (e.g. [WebKit does it](https://github.com/WebKit/WebKit/blob/b87b8693fbbbde7c811585bbf0c2292222249fa4/Source/WebCore/dom/Document.cpp#L7330)). This results in teared state when some components receive updates faster than others and it happens within one micro-task. 

