### PR TITLE
Types: remove hacks, `ReactElement` and `VNode`

### DIFF
--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -95,7 +95,7 @@ export type RedirectProps<H extends BaseLocationHook = BrowserLocationHook> =
 export function Redirect<H extends BaseLocationHook = BrowserLocationHook>(
   props: RedirectProps<H>,
   context?: any
-): VNode<any> | null;
+): null;
 export function Link<H extends BaseLocationHook = BrowserLocationHook>(
   props: LinkProps<H>,
   context?: any

--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -6,7 +6,6 @@ import {
   FunctionComponent,
   ComponentType,
   ComponentChildren,
-  VNode,
 } from "preact";
 
 import {
@@ -70,7 +69,7 @@ export interface RouteProps<
 export function Route<
   T extends DefaultParams | undefined = undefined,
   RoutePath extends Path = Path
->(props: RouteProps<T, RoutePath>): VNode<any> | null;
+>(props: RouteProps<T, RoutePath>): ReturnType<FunctionComponent>;
 
 /*
  * Components: <Link /> & <Redirect />
@@ -96,10 +95,11 @@ export function Redirect<H extends BaseLocationHook = BrowserLocationHook>(
   props: RedirectProps<H>,
   context?: any
 ): null;
+
 export function Link<H extends BaseLocationHook = BrowserLocationHook>(
   props: LinkProps<H>,
   context?: any
-): VNode<any> | null;
+): ReturnType<FunctionComponent>;
 
 /*
  * Components: <Switch />
@@ -107,7 +107,7 @@ export function Link<H extends BaseLocationHook = BrowserLocationHook>(
 
 export interface SwitchProps {
   location?: string;
-  children: Array<VNode<RouteProps>>;
+  children: ComponentChildren;
 }
 export const Switch: FunctionComponent<SwitchProps>;
 

--- a/packages/wouter/test/redirect.test-d.tsx
+++ b/packages/wouter/test/redirect.test-d.tsx
@@ -23,4 +23,13 @@ describe("Redirect types", () => {
 
     assertType<null>(Redirect({ href: "/" }));
   });
+
+  it("can not accept children", () => {
+    // @ts-expect-error
+    <Redirect href="/">hi!</Redirect>;
+
+    // prettier-ignore
+    // @ts-expect-error
+    <Redirect href="/"><><div>Fragment</div></></Redirect>;
+  });
 });

--- a/packages/wouter/test/redirect.test-d.tsx
+++ b/packages/wouter/test/redirect.test-d.tsx
@@ -14,4 +14,13 @@ describe("Redirect types", () => {
     assertType(<Redirect href="/" state={undefined} />);
     assertType(<Redirect href="/" state="string" />);
   });
+
+  it("always renders nothing", () => {
+    // can be used in JSX
+    <div>
+      <Redirect href="/" />
+    </div>;
+
+    assertType<null>(Redirect({ href: "/" }));
+  });
 });

--- a/packages/wouter/test/route.test-d.tsx
+++ b/packages/wouter/test/route.test-d.tsx
@@ -67,14 +67,18 @@ it("supports functions as children", () => {
     }}
   </Route>;
 
-  // @ts-expect-error function should return JSX
-  <Route path="/app">{() => {}}</Route>;
-
   <Route path="/users/:id">{({ id }) => `User id: ${id}`}</Route>;
 
   <Route path="/users/:id">
     {({ age }: { age: string }) => `User age: ${age}`}
   </Route>;
+
+  // @ts-expect-error function should return valid JSX
+  <Route path="/app">{() => {}}</Route>;
+
+  // prettier-ignore
+  // @ts-expect-error you can't use JSX together with render function
+  <Route path="/">{() => <div />}<a>Link</a></Route>;
 });
 
 describe("parameter inference", () => {

--- a/packages/wouter/test/use-hash-location.test.tsx
+++ b/packages/wouter/test/use-hash-location.test.tsx
@@ -152,7 +152,7 @@ it("works even if `hashchange` listeners are called asynchronously ", async () =
     children: ReactNode;
   }) => {
     useSyncExternalStore(subscribeToHashchange, () => true);
-    return children;
+    return <>{children}</>;
   };
 
   const paths: string[] = [];

--- a/packages/wouter/test/use-hash-location.test.tsx
+++ b/packages/wouter/test/use-hash-location.test.tsx
@@ -6,7 +6,7 @@ import { Router, Route, useLocation } from "wouter";
 import { useHashLocation } from "wouter/use-hash-location";
 
 import { waitForHashChangeEvent } from "./test-utils";
-import { ReactElement, useSyncExternalStore } from "react";
+import { ReactNode, useSyncExternalStore } from "react";
 
 beforeEach(() => {
   history.replaceState(null, "", "/");
@@ -149,7 +149,7 @@ it("works even if `hashchange` listeners are called asynchronously ", async () =
   const InterceptAndStopHashchange = ({
     children,
   }: {
-    children: ReactElement;
+    children: ReactNode;
   }) => {
     useSyncExternalStore(subscribeToHashchange, () => true);
     return children;

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -97,7 +97,7 @@ export type RedirectProps<H extends BaseLocationHook = BrowserLocationHook> =
   };
 
 export function Redirect<H extends BaseLocationHook = BrowserLocationHook>(
-  props: PropsWithChildren<RedirectProps<H>>,
+  props: RedirectProps<H>,
   context?: any
 ): null;
 

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -99,7 +99,7 @@ export type RedirectProps<H extends BaseLocationHook = BrowserLocationHook> =
 export function Redirect<H extends BaseLocationHook = BrowserLocationHook>(
   props: PropsWithChildren<RedirectProps<H>>,
   context?: any
-): ReactElement<any, any> | null;
+): null;
 
 export function Link<H extends BaseLocationHook = BrowserLocationHook>(
   props: PropsWithChildren<LinkProps<H>> & RefAttributes<HTMLAnchorElement>,

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -8,7 +8,6 @@ import {
   PropsWithChildren,
   RefAttributes,
   ComponentType,
-  ReactElement,
   ReactNode,
 } from "react";
 
@@ -74,7 +73,7 @@ export interface RouteProps<
 export function Route<
   T extends DefaultParams | undefined = undefined,
   RoutePath extends Path = Path
->(props: RouteProps<T, RoutePath>): ReactElement | null;
+>(props: RouteProps<T, RoutePath>): ReturnType<FunctionComponent>;
 
 /*
  * Components: <Link /> & <Redirect />
@@ -104,7 +103,7 @@ export function Redirect<H extends BaseLocationHook = BrowserLocationHook>(
 export function Link<H extends BaseLocationHook = BrowserLocationHook>(
   props: PropsWithChildren<LinkProps<H>> & RefAttributes<HTMLAnchorElement>,
   context?: any
-): ReactElement<any, any> | null;
+): ReturnType<FunctionComponent>;
 
 /*
  * Components: <Switch />

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -9,8 +9,7 @@ import {
   RefAttributes,
   ComponentType,
   ReactElement,
-  ReactChild,
-  ReactPortal,
+  ReactNode,
 } from "react";
 
 import {
@@ -29,17 +28,6 @@ export { Path, BaseLocationHook, BaseSearchHook } from "./location-hook";
 export * from "./router";
 
 import { RouteParams } from "./regexparam";
-
-// React <18 only: fixes incorrect `ReactNode` declaration that had `{}` in the union.
-// This issue has been fixed in React 18 type declaration.
-// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210
-type ReactNode =
-  | ReactChild
-  | Iterable<ReactNode>
-  | ReactPortal
-  | boolean
-  | null
-  | undefined;
 
 /**
  * Route patterns and parameters


### PR DESCRIPTION
- Removes `ReactNode` type override. This makes types in React 17 less strict, but nothing should break.
- Refactor definitions to stop using `ReactElement` when possible. See https://www.totaltypescript.com/jsx-element-vs-react-reactnode

We are getting really close to unifying React and Preact defs!