### PR TITLE
Allow links to accept `onClick` when used in `asChild` mode

### DIFF
--- a/packages/wouter-preact/test/preact.test.tsx
+++ b/packages/wouter-preact/test/preact.test.tsx
@@ -18,31 +18,40 @@ describe("Preact support", () => {
     const container = document.body.appendChild(document.createElement("div"));
     const fn = vi.fn();
 
-    const App = () => (
-      <>
-        <nav>
-          <Link href="/albums/all" onClick={fn} data-testid="index-link">
-            The Best Albums Ever
-          </Link>
-          <Link to="/albums/london-calling" asChild>
-            <a data-testid="featured-link">
-              Featured Now: London Calling, Clash
-            </a>
-          </Link>
-        </nav>
+    const App = () => {
+      const handleAsChildClick = vi.fn();
 
-        <main data-testid="routes">
-          <Switch>
-            <>Welcome to the list of {100} greatest albums of all time!</>
-            <Route path="/albums/all">Rolling Stones Best 100 Albums</Route>
-            <Route path="/albums/:name">
-              {(params) => `Album ${params.name}`}
-            </Route>
-            <Route path="*">Nothing was found!</Route>
-          </Switch>
-        </main>
-      </>
-    );
+      return (
+        <>
+          <nav>
+            <Link href="/albums/all" onClick={fn} data-testid="index-link">
+              The Best Albums Ever
+            </Link>
+
+            <Link
+              to="/albums/london-calling"
+              asChild
+              onClick={handleAsChildClick}
+            >
+              <a data-testid="featured-link">
+                Featured Now: London Calling, Clash
+              </a>
+            </Link>
+          </nav>
+
+          <main data-testid="routes">
+            <Switch>
+              <>Welcome to the list of {100} greatest albums of all time!</>
+              <Route path="/albums/all">Rolling Stones Best 100 Albums</Route>
+              <Route path="/albums/:name">
+                {(params) => `Album ${params.name}`}
+              </Route>
+              <Route path="*">Nothing was found!</Route>
+            </Switch>
+          </main>
+        </>
+      );
+    };
 
     let node = render(<App />, container);
 

--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -80,16 +80,16 @@ export type NavigationalProps<
 > = ({ to: Path; href?: never } | { href: Path; to?: never }) &
   HookNavigationOptions<H>;
 
-type AsChildProps<ComponentProps, DefaultElementProps, AsChildProps = {}> =
-  | ({ asChild?: false } & DefaultElementProps & ComponentProps)
-  | ({ asChild: true } & AsChildProps & ComponentProps);
+type AsChildProps<ComponentProps, DefaultElementProps> =
+  | ({ asChild?: false } & DefaultElementProps)
+  | ({ asChild: true } & ComponentProps);
 
 export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> =
-  AsChildProps<
-    NavigationalProps<H>,
-    JSX.HTMLAttributes,
-    { children: ComponentChildren; onClick?: JSX.MouseEventHandler<Element> }
-  >;
+  NavigationalProps<H> &
+    AsChildProps<
+      { children: ComponentChildren; onClick?: JSX.MouseEventHandler<Element> },
+      JSX.HTMLAttributes
+    >;
 
 export type RedirectProps<H extends BaseLocationHook = BrowserLocationHook> =
   NavigationalProps<H> & {

--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -80,12 +80,16 @@ export type NavigationalProps<
 > = ({ to: Path; href?: never } | { href: Path; to?: never }) &
   HookNavigationOptions<H>;
 
-type AsChildProps<ComponentProps, DefaultElementProps> =
-  | ({ asChild?: false } & ComponentProps & DefaultElementProps)
-  | ({ asChild: true; children: ComponentChildren } & ComponentProps);
+type AsChildProps<ComponentProps, DefaultElementProps, AsChildProps = {}> =
+  | ({ asChild?: false } & DefaultElementProps & ComponentProps)
+  | ({ asChild: true } & AsChildProps & ComponentProps);
 
 export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> =
-  AsChildProps<NavigationalProps<H>, JSX.HTMLAttributes>;
+  AsChildProps<
+    NavigationalProps<H>,
+    JSX.HTMLAttributes,
+    { children: ComponentChildren; onClick?: JSX.MouseEventHandler<Element> }
+  >;
 
 export type RedirectProps<H extends BaseLocationHook = BrowserLocationHook> =
   NavigationalProps<H> & {

--- a/packages/wouter/test/link.test-d.tsx
+++ b/packages/wouter/test/link.test-d.tsx
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, expectTypeOf, it } from "vitest";
 import { Link, type Path } from "wouter";
 import * as React from "react";
 
@@ -114,6 +114,19 @@ describe("<Link /> with `asChild` prop", () => {
     </Link>;
   });
 
+  it("can only have valid element as a child", () => {
+    // @ts-expect-error strings are not valid children
+    <Link to="/" asChild>
+      {true ? "Hello" : "World"}
+    </Link>;
+
+    // @ts-expect-error can't use multiple nodes as children
+    <Link to="/" asChild>
+      <a>Link</a>
+      <div>icon</div>
+    </Link>;
+  });
+
   it("does not allow other props", () => {
     // @ts-expect-error
     <Link to="/" asChild className="">
@@ -163,6 +176,18 @@ describe("<Link /> with `asChild` prop", () => {
 
     <Link<NetworkLocationHook> asChild to="/" host="wouter.com" retries={4}>
       <div>test</div>
+    </Link>;
+  });
+
+  it("accepts `onClick` prop that overwrites child's handler", () => {
+    <Link
+      to="/"
+      asChild
+      onClick={(e) => {
+        expectTypeOf(e).toEqualTypeOf<React.MouseEvent>();
+      }}
+    >
+      <a>Hello</a>
     </Link>;
   });
 });

--- a/packages/wouter/test/link.test.tsx
+++ b/packages/wouter/test/link.test.tsx
@@ -187,6 +187,7 @@ describe("<Link /> with `asChild` prop", () => {
 
   it("when invalid element is provided, wraps the children in an <a />", () => {
     const { getByText } = render(
+      /* @ts-expect-error */
       <Link href="/about" asChild>
         Click Me
       </Link>
@@ -201,6 +202,7 @@ describe("<Link /> with `asChild` prop", () => {
 
   it("when more than one element is provided, wraps the children in an <a />", async () => {
     const { getByText } = render(
+      /* @ts-expect-error */
       <Link href="/about" asChild>
         <span>1</span>
         <span>2</span>

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -8,6 +8,8 @@ import {
   RefAttributes,
   ComponentType,
   ReactNode,
+  ReactElement,
+  MouseEventHandler,
 } from "react";
 
 import {
@@ -93,14 +95,15 @@ export function Redirect<H extends BaseLocationHook = BrowserLocationHook>(
   context?: any
 ): null;
 
-type AsChildProps<ComponentProps, DefaultElementProps> =
-  | ({ asChild?: false } & ComponentProps & DefaultElementProps)
-  | ({ asChild: true; children: React.ReactNode } & ComponentProps);
+type AsChildProps<ComponentProps, DefaultElementProps, AsChildProps = {}> =
+  | ({ asChild?: false } & DefaultElementProps & ComponentProps)
+  | ({ asChild: true } & AsChildProps & ComponentProps);
 
 export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> =
   AsChildProps<
     NavigationalProps<H>,
-    AnchorHTMLAttributes<HTMLAnchorElement> & RefAttributes<HTMLAnchorElement>
+    AnchorHTMLAttributes<HTMLAnchorElement> & RefAttributes<HTMLAnchorElement>,
+    { children: ReactElement; onClick?: MouseEventHandler }
   >;
 
 export function Link<H extends BaseLocationHook = BrowserLocationHook>(

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -5,7 +5,6 @@
 import {
   AnchorHTMLAttributes,
   FunctionComponent,
-  PropsWithChildren,
   RefAttributes,
   ComponentType,
   ReactNode,

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -95,16 +95,16 @@ export function Redirect<H extends BaseLocationHook = BrowserLocationHook>(
   context?: any
 ): null;
 
-type AsChildProps<ComponentProps, DefaultElementProps, AsChildProps = {}> =
-  | ({ asChild?: false } & DefaultElementProps & ComponentProps)
-  | ({ asChild: true } & AsChildProps & ComponentProps);
+type AsChildProps<ComponentProps, DefaultElementProps> =
+  | ({ asChild?: false } & DefaultElementProps)
+  | ({ asChild: true } & ComponentProps);
 
 export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> =
-  AsChildProps<
-    NavigationalProps<H>,
-    AnchorHTMLAttributes<HTMLAnchorElement> & RefAttributes<HTMLAnchorElement>,
-    { children: ReactElement; onClick?: MouseEventHandler }
-  >;
+  NavigationalProps<H> &
+    AsChildProps<
+      { children: ReactElement; onClick?: MouseEventHandler },
+      AnchorHTMLAttributes<HTMLAnchorElement> & RefAttributes<HTMLAnchorElement>
+    >;
 
 export function Link<H extends BaseLocationHook = BrowserLocationHook>(
   props: LinkProps<H>,


### PR DESCRIPTION
Also, I narrowed the type of children to be a valid React element.