### PR TITLE
Types: Make `LinkProps` return a proper type

### DIFF
--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -22,8 +22,9 @@ import {
 
 import { RouterObject, RouterOptions } from "./router.js";
 
-// re-export some types from these modules
-export { Path, BaseLocationHook, BaseSearchHook } from "./location-hook.js";
+// these files only export types, so we can re-export them as-is
+// in TS 5.0 we'll be able to use `export type * from ...`
+export * from "./location-hook.js";
 export * from "./router.js";
 
 import { RouteParams } from "regexparam";

--- a/packages/wouter/test/link.test-d.tsx
+++ b/packages/wouter/test/link.test-d.tsx
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { Link, type Path } from "wouter";
+import { Link, LinkProps, type Path } from "wouter";
 import * as React from "react";
 
 type NetworkLocationHook = () => [
@@ -189,5 +189,12 @@ describe("<Link /> with `asChild` prop", () => {
     >
       <a>Hello</a>
     </Link>;
+  });
+
+  it.skip("should work with `ComponentProps`", () => {
+    type LinkComponentProps = React.ComponentProps<typeof Link>;
+
+    // @ts-expect-error FIXME
+    expectTypeOf<LinkComponentProps>().toEqualTypeOf<LinkProps>();
   });
 });

--- a/packages/wouter/test/link.test-d.tsx
+++ b/packages/wouter/test/link.test-d.tsx
@@ -191,10 +191,13 @@ describe("<Link /> with `asChild` prop", () => {
     </Link>;
   });
 
-  it.skip("should work with `ComponentProps`", () => {
+  it("should work with `ComponentProps`", () => {
     type LinkComponentProps = React.ComponentProps<typeof Link>;
 
-    // @ts-expect-error FIXME
-    expectTypeOf<LinkComponentProps>().toEqualTypeOf<LinkProps>();
+    // Because Link is a generic component, the props
+    // cant't contain navigation options of the default generic
+    // parameter `BrowserLocationHook`.
+    // So the best we can get are the props such as `href` etc.
+    expectTypeOf<LinkComponentProps>().toMatchTypeOf<LinkProps>();
   });
 });

--- a/packages/wouter/test/location-hook.test-d.ts
+++ b/packages/wouter/test/location-hook.test-d.ts
@@ -1,0 +1,66 @@
+import { it, assertType, expectTypeOf, describe, expect } from "vitest";
+import {
+  BaseLocationHook,
+  HookNavigationOptions,
+  HookReturnValue,
+} from "wouter";
+
+describe("`HookNavigationOptions` utility type", () => {
+  it("should return empty interface for hooks with no nav options", () => {
+    const hook = (): [string, (path: string) => void] => {
+      return ["stub", (path: string) => {}];
+    };
+
+    type A = HookReturnValue<typeof hook>[1];
+    type Options = HookNavigationOptions<typeof hook>;
+
+    expectTypeOf<Options>().toEqualTypeOf<{}>();
+
+    const optionsExt: Options | { a: 1 } = { a: 1, b: 2 };
+  });
+
+  it("should return object with required navigation params", () => {
+    const hook = (): [
+      string,
+      (path: string, options: { replace: boolean; optional?: number }) => void
+    ] => {
+      return ["stub", () => {}];
+    };
+
+    type Options = HookNavigationOptions<typeof hook>;
+
+    // @ts-expect-error
+    expectTypeOf<Options>().toEqualTypeOf<{
+      replace: boolean;
+      foo: string;
+    }>();
+
+    expectTypeOf<Options>().toEqualTypeOf<{
+      replace: boolean;
+      optional?: number;
+    }>();
+  });
+
+  it("should not contain never when options are optional", () => {
+    const hook = (
+      param: string
+    ): [string, (path: string, options?: { replace: boolean }) => void] => {
+      return ["stub", () => {}];
+    };
+
+    type Options = HookNavigationOptions<typeof hook>;
+
+    expectTypeOf<Options>().toEqualTypeOf<{
+      replace: boolean;
+    }>();
+  });
+
+  it("should only support valid hooks", () => {
+    // @ts-expect-error
+    type A = HookNavigationOptions<string>;
+    // @ts-expect-error
+    type B = HookNavigationOptions<{}>;
+    // @ts-expect-error
+    type C = HookNavigationOptions<() => []>;
+  });
+});

--- a/packages/wouter/test/location-hook.test-d.ts
+++ b/packages/wouter/test/location-hook.test-d.ts
@@ -1,9 +1,5 @@
-import { it, assertType, expectTypeOf, describe, expect } from "vitest";
-import {
-  BaseLocationHook,
-  HookNavigationOptions,
-  HookReturnValue,
-} from "wouter";
+import { it, expectTypeOf, describe } from "vitest";
+import { HookNavigationOptions, HookReturnValue } from "wouter";
 
 describe("`HookNavigationOptions` utility type", () => {
   it("should return empty interface for hooks with no nav options", () => {

--- a/packages/wouter/test/location-hook.test-d.ts
+++ b/packages/wouter/test/location-hook.test-d.ts
@@ -1,5 +1,9 @@
 import { it, expectTypeOf, describe } from "vitest";
-import { HookNavigationOptions, HookReturnValue } from "wouter";
+import {
+  BaseLocationHook,
+  HookNavigationOptions,
+  HookReturnValue,
+} from "wouter";
 
 describe("`HookNavigationOptions` utility type", () => {
   it("should return empty interface for hooks with no nav options", () => {
@@ -7,7 +11,6 @@ describe("`HookNavigationOptions` utility type", () => {
       return ["stub", (path: string) => {}];
     };
 
-    type A = HookReturnValue<typeof hook>[1];
     type Options = HookNavigationOptions<typeof hook>;
 
     expectTypeOf<Options>().toEqualTypeOf<{}>();
@@ -58,5 +61,12 @@ describe("`HookNavigationOptions` utility type", () => {
     type B = HookNavigationOptions<{}>;
     // @ts-expect-error
     type C = HookNavigationOptions<() => []>;
+  });
+
+  it("should return arbitrary object when `BaseLocationHook` is given", () => {
+    type Options = HookNavigationOptions<BaseLocationHook>;
+
+    const opts: Options = { a: 1, b: 2 };
+    opts.anything = 1;
   });
 });

--- a/packages/wouter/test/location-hook.test-d.ts
+++ b/packages/wouter/test/location-hook.test-d.ts
@@ -1,9 +1,5 @@
 import { it, expectTypeOf, describe } from "vitest";
-import {
-  BaseLocationHook,
-  HookNavigationOptions,
-  HookReturnValue,
-} from "wouter";
+import { BaseLocationHook, HookNavigationOptions } from "wouter";
 
 describe("`HookNavigationOptions` utility type", () => {
   it("should return empty interface for hooks with no nav options", () => {
@@ -63,10 +59,8 @@ describe("`HookNavigationOptions` utility type", () => {
     type C = HookNavigationOptions<() => []>;
   });
 
-  it("should return arbitrary object when `BaseLocationHook` is given", () => {
+  it("should return empty object when `BaseLocationHook` is given", () => {
     type Options = HookNavigationOptions<BaseLocationHook>;
-
-    const opts: Options = { a: 1, b: 2 };
-    opts.anything = 1;
+    expectTypeOf<Options>().toEqualTypeOf<{}>();
   });
 });

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -26,8 +26,9 @@ import {
 
 import { RouterObject, RouterOptions } from "./router.js";
 
-// re-export some types from these modules
-export { Path, BaseLocationHook, BaseSearchHook } from "./location-hook.js";
+// these files only export types, so we can re-export them as-is
+// in TS 5.0 we'll be able to use `export type * from ...`
+export * from "./location-hook.js";
 export * from "./router.js";
 
 import { RouteParams } from "regexparam";

--- a/packages/wouter/types/location-hook.d.ts
+++ b/packages/wouter/types/location-hook.d.ts
@@ -21,16 +21,15 @@ export type BaseSearchHook = (...args: any[]) => SearchString;
 // Returns the type of the location tuple of the given hook.
 export type HookReturnValue<H extends BaseLocationHook> = ReturnType<H>;
 
-// Utility type that allows us to distinguish between hooks that
-// don't receive any options and `BaseLocationHook` that can accept anything
-type ArbitraryObjectWhenNever<T> = 0 extends 1 & T
-  ? { [key: string]: any }
+// Utility type that allows us to handle cases like `any` and `never`
+type EmptyInterfaceWhenAnyOrNever<T> = 0 extends 1 & T
+  ? {}
   : [T] extends [never]
   ? {}
   : T;
 
 // Returns the type of the navigation options that hook's push function accepts.
 export type HookNavigationOptions<H extends BaseLocationHook> =
-  ArbitraryObjectWhenNever<
+  EmptyInterfaceWhenAnyOrNever<
     NonNullable<Parameters<HookReturnValue<H>[1]>[1]> // get's the second argument of a tuple returned by the hook
   >;

--- a/packages/wouter/types/location-hook.d.ts
+++ b/packages/wouter/types/location-hook.d.ts
@@ -21,8 +21,16 @@ export type BaseSearchHook = (...args: any[]) => SearchString;
 // Returns the type of the location tuple of the given hook.
 export type HookReturnValue<H extends BaseLocationHook> = ReturnType<H>;
 
-type EmptyOptionsWhenNever<T> = [T] extends [never] ? {} : T;
+// Utility type that allows us to distinguish between hooks that
+// don't receive any options and `BaseLocationHook` that can accept anything
+type ArbitraryObjectWhenNever<T> = 0 extends 1 & T
+  ? { [key: string]: any }
+  : [T] extends [never]
+  ? {}
+  : T;
 
 // Returns the type of the navigation options that hook's push function accepts.
 export type HookNavigationOptions<H extends BaseLocationHook> =
-  EmptyOptionsWhenNever<NonNullable<Parameters<HookReturnValue<H>[1]>[1]>>;
+  ArbitraryObjectWhenNever<
+    NonNullable<Parameters<HookReturnValue<H>[1]>[1]> // get's the second argument of a tuple returned by the hook
+  >;

--- a/packages/wouter/types/location-hook.d.ts
+++ b/packages/wouter/types/location-hook.d.ts
@@ -21,14 +21,8 @@ export type BaseSearchHook = (...args: any[]) => SearchString;
 // Returns the type of the location tuple of the given hook.
 export type HookReturnValue<H extends BaseLocationHook> = ReturnType<H>;
 
+type EmptyOptionsWhenNever<T> = [T] extends [never] ? {} : T;
+
 // Returns the type of the navigation options that hook's push function accepts.
 export type HookNavigationOptions<H extends BaseLocationHook> =
-  HookReturnValue<H>[1] extends (
-    path: Path,
-    options: infer R,
-    ...rest: any[]
-  ) => any
-    ? R extends { [k: string]: any }
-      ? R
-      : {}
-    : {};
+  EmptyOptionsWhenNever<NonNullable<Parameters<HookReturnValue<H>[1]>[1]>>;


### PR DESCRIPTION
1. Re-export utility types for working with navigation options
2. Cover `HookNavigationOptions` with type specs
3. Refactor `HookNavigationOptions` and make it work with empty options and arbitrary options

Unfortunately, `ComponentProps<typeof Link>` will still not work, I don't have ideas how to fix this yet (it basically assumes that `Hook` generic parameter is `BaseLocationHook` and not `BrowserLocationHook`, see skipped test case). Do you have any suggestions? Exported type `LinkProps` does work though.

