### PR TITLE
Fix location and search decoding

### DIFF
--- a/packages/wouter/src/paths.js
+++ b/packages/wouter/src/paths.js
@@ -20,7 +20,7 @@ export const stripQm = (str) => (str[0] === "?" ? str.slice(1) : str);
  */
 export const unescape = (str) => {
   try {
-    return decodeURIComponent(str);
+    return decodeURI(str);
   } catch (_e) {
     // fail-safe mode: if string can't be decoded do nothing
     return str;

--- a/packages/wouter/test/use-route.test.tsx
+++ b/packages/wouter/test/use-route.test.tsx
@@ -101,6 +101,13 @@ it("supports other characters in segments", () => {
   });
 });
 
+it("ignores escaped slashes", () => {
+  assertRoute("/:param/bar", "/foo%2Fbar/bar", { param: "foo%2Fbar" });
+  assertRoute("/:param", "/foo%2Fbar%D1%81%D0%B0%D0%BD%D1%8F", {
+    param: "foo%2Fbarсаня",
+  });
+});
+
 it("reacts to pattern updates", () => {
   const { result, rerender } = renderHook(
     ({ pattern }: { pattern: string }) => useRoute(pattern),

--- a/packages/wouter/test/use-search.test.tsx
+++ b/packages/wouter/test/use-search.test.tsx
@@ -36,3 +36,13 @@ it("unescapes search string", () => {
   act(() => navigate("/?вопрос=как дела?"));
   expect(searchResult.current).toBe("вопрос=как дела?");
 });
+
+it("is safe against parameter injection", () => {
+  history.replaceState(null, "", "/?search=foo%26parameter_injection%3Dbar");
+  const { result } = renderHook(() => useSearch());
+
+  const searchParams = new URLSearchParams(result.current);
+  const query = Object.fromEntries(searchParams.entries());
+
+  expect(query).toEqual({ search: "foo&parameter_injection=bar" });
+});


### PR DESCRIPTION
Fixes #402 #400 

Replaces `decodeURIComponent` with `decodeURI` to ignore escaped slashes and `&` when parsing location and query string.