### PR TITLE
docs: fix colon in front of dynamic segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ const [match, params] = useRoute("/users/:name");
 Express, and it supports the following patterns:
 
 - Named dynamic segments: `/users/:foo`.
-- Dynamic segments with modifiers: `/foo/:bar*`, `/foo/baz?` or `/foo/bar+`.
+- Dynamic segments with modifiers: `/foo/:bar*`, `/foo/:baz?` or `/foo/:bar+`.
 
 The library was designed to be as small as possible, so most of the additional matching features
 were left out (see [this issue](https://github.com/molefrog/wouter/issues/1) for more info).


### PR DESCRIPTION
The regex quantifiers in the documentation for dynamic segments were missing a colon, which is probably unwanted in my opinion.