### PR TITLE
Use `const keys` in `pathToRegexp` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ import { pathToRegexp } from "path-to-regexp";
  * Custom parser based on `pathToRegexp` with strict route option
  */
 const strictParser = (path, loose) => {
-  let keys = [];
+  const keys = [];
   const pattern = pathToRegexp(path, keys, { strict: true, end: !loose });
 
   return {


### PR DESCRIPTION
`pathToRegexp` does not create a new array and it couldn't even work if it did because the variable binding would be lost. So this can be `const` and it does also match the module's docs:

https://github.com/pillarjs/path-to-regexp#path-to-regexp-1