### PR TITLE
Feat: Extract `ssrSearch` from `ssrPath` when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,15 @@ const handleRequest = (req, res) => {
 };
 ```
 
+Tip: wouter can pre-fill `ssrSearch`, if `ssrPath` contains the `?` character. So these are equivalent:
+
+```jsx
+<Router ssrPath="/goods?sort=asc" />;
+
+// is the same as
+<Router ssrPath="/goods" ssrSearch="sort=asc" />;
+```
+
 On the client, the static markup must be hydrated in order for your app to become interactive. Note
 that to avoid having hydration warnings, the JSX rendered on the client must match the one used by
 the server, so the `Router` component must be present.

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -116,6 +116,10 @@ export const Router = ({ children, ...props }) => {
   // holds to the context value: the router object
   let value = parent;
 
+  // when `ssrPath` contains a `?` character, we split can extract the search
+  const [path, search] = props.ssrPath?.split("?") ?? [];
+  if (search) (props.ssrSearch = search), (props.ssrPath = path);
+
   // what is happening below: to avoid unnecessary rerenders in child components,
   // we ensure that the router object reference is stable, unless there are any
   // changes that require reload (e.g. `base` prop changes -> all components that

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -116,7 +116,7 @@ export const Router = ({ children, ...props }) => {
   // holds to the context value: the router object
   let value = parent;
 
-  // when `ssrPath` contains a `?` character, we split can extract the search
+  // when `ssrPath` contains a `?` character, we can extract the search from it
   const [path, search] = props.ssrPath?.split("?") ?? [];
   if (search) (props.ssrSearch = search), (props.ssrPath = path);
 

--- a/packages/wouter/test/router.test.tsx
+++ b/packages/wouter/test/router.test.tsx
@@ -51,6 +51,45 @@ it("alters the current router with `parser` and `hook` options", () => {
   expect(router.hook).toBe(hook);
 });
 
+it("accepts `ssrPath` and `ssrSearch` params", () => {
+  const { result } = renderHook(() => useRouter(), {
+    wrapper: (props) => (
+      <Router ssrPath="/users" ssrSearch="a=b&c=d">
+        {props.children}
+      </Router>
+    ),
+  });
+
+  expect(result.current.ssrPath).toBe("/users");
+  expect(result.current.ssrSearch).toBe("a=b&c=d");
+});
+
+it("can extract `ssrSearch` from `ssrPath` after the '?' symbol", () => {
+  let ssrPath: string | undefined = "/no-search";
+  let ssrSearch: string | undefined = undefined;
+
+  const { result, rerender } = renderHook(() => useRouter(), {
+    wrapper: (props) => (
+      <Router ssrPath={ssrPath} ssrSearch={ssrSearch}>
+        {props.children}
+      </Router>
+    ),
+  });
+
+  expect(result.current.ssrPath).toBe("/no-search");
+  expect(result.current.ssrSearch).toBe(undefined);
+
+  ssrPath = "/with-search?a=b&c=d";
+  rerender();
+
+  expect(result.current.ssrPath).toBe("/with-search");
+  expect(result.current.ssrSearch).toBe("a=b&c=d");
+
+  ssrSearch = "x=y&z=w";
+  rerender();
+  expect(result.current.ssrSearch).toBe("a=b&c=d");
+});
+
 it("shares one router instance between components", () => {
   const RouterGetter = ({ el }: { el: ReactElement }) => {
     const router = useRouter();


### PR DESCRIPTION
When `ssrPath` contains a `?` character, we can extract `ssrSearch` from it. Example:

```jsx
// `ssrSearch` is "order=asc" 
<Router ssrPath="/blog?order=asc" />
```