### PR TITLE
Fix: add nest prop to Preact types, in line with React types

### DIFF
--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -68,6 +68,7 @@ export interface RouteProps<
   component?: ComponentType<
     RouteComponentProps<T extends DefaultParams ? T : RouteParams<RoutePath>>
   >;
+  nest?: boolean;
 }
 
 export function Route<


### PR DESCRIPTION
Am I wrong that this is just an oversight in the types? The Preact package mostly just imports the React one. I did double-check the rest of the file and everything looks equivalent besides this.