### PR TITLE
Fix compilation error on React < 18

### DIFF
--- a/packages/wouter/src/react-deps.js
+++ b/packages/wouter/src/react-deps.js
@@ -1,12 +1,14 @@
 import * as React from "react";
 
-// React.useInsertionEffect is not available in React <18
 const {
   useEffect,
   useLayoutEffect,
   useRef,
-  useInsertionEffect: useBuiltinInsertionEffect,
 } = React;
+
+// React.useInsertionEffect is not available in React <18
+// This hack fixes a transpilation issue on some apps
+const useBuiltinInsertionEffect = React['useInsertion' + 'Effect'];
 
 export {
   useRef,


### PR DESCRIPTION
The error was `Attempted import error: 'useInsertionEffect' is not exported from 'react' (imported as 'React').`

I have used the same technique as Emotion https://github.com/emotion-js/emotion/commit/75a2f74418019819e0cdcb1e0720b0a5d0d65687#diff-e87fa5e3ae2595fc1671477ceb9c7327f968d5556791d29958210ed43474fc92R17