### PR TITLE
fix react-deps.js

### DIFF
--- a/packages/wouter/src/react-deps.js
+++ b/packages/wouter/src/react-deps.js
@@ -11,7 +11,6 @@ const {
 const useBuiltinInsertionEffect = React['useInsertion' + 'Effect'];
 
 export {
-  useRef,
   useState,
   useContext,
   createContext,


### PR DESCRIPTION
fix RollupError: [commonjs--resolver] node_modules/wouter/esm/react-deps.js (8:2): Identifier "useRef" has already been declared