### PR TITLE
chore: tweak imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6499,7 +6499,7 @@
       }
     },
     "packages/wouter": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "license": "Unlicense",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -6511,7 +6511,7 @@
       }
     },
     "packages/wouter-preact": {
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "Unlicense",
       "dependencies": {
         "mitt": "^3.0.1",

--- a/packages/wouter/src/react-deps.js
+++ b/packages/wouter/src/react-deps.js
@@ -1,11 +1,5 @@
 import * as React from "react";
 
-const {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-} = React;
-
 // React.useInsertionEffect is not available in React <18
 // This hack fixes a transpilation issue on some apps
 const useBuiltinInsertionEffect = React['useInsertion' + 'Effect'];
@@ -43,8 +37,8 @@ const canUseDOM = !!(
 // To get around it, we can conditionally useEffect on the server (no-op) and
 // useLayoutEffect in the browser."
 export const useIsomorphicLayoutEffect = canUseDOM
-  ? useLayoutEffect
-  : useEffect;
+  ? React.useLayoutEffect
+  : React.useEffect;
 
 // useInsertionEffect is already a noop on the server.
 // See: https://github.com/facebook/react/blob/main/packages/react-server/src/ReactFizzHooks.js
@@ -58,7 +52,7 @@ export const useInsertionEffect =
 // .current at the right timing."
 // So we will have to make do with this "close enough" approach for now.
 export const useEvent = (fn) => {
-  const ref = useRef([fn, (...args) => ref[0](...args)]).current;
+  const ref = React.useRef([fn, (...args) => ref[0](...args)]).current;
   // Per Dan Abramov: useInsertionEffect executes marginally closer to the
   // correct timing for ref synchronization than useLayoutEffect on React 18.
   // See: https://github.com/facebook/react/pull/25881#issuecomment-1356244360

--- a/packages/wouter/src/react-deps.js
+++ b/packages/wouter/src/react-deps.js
@@ -2,7 +2,7 @@ import * as React from "react";
 
 // React.useInsertionEffect is not available in React <18
 // This hack fixes a transpilation issue on some apps
-const useBuiltinInsertionEffect = React['useInsertion' + 'Effect'];
+const useBuiltinInsertionEffect = React["useInsertion" + "Effect"];
 
 export {
   useRef,


### PR DESCRIPTION
remove destructuring assignment for react wildcard import because it prevents tree-shaking and removing makes code little bit smaller