### PR TITLE
Added support for regular expressions in paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ useRoute("/orders/*?");
 
 // regex for matching complex patterns,
 // matches "/hello:123"
-useRoute(/[/]([a-z]+):([0-9]+)[/]?/);
+useRoute(/^[/]([a-z]+):([0-9]+)[/]?$/);
 // and with named capture groups
-useRoute(/[/](?<word>[a-z]+):(?<num>[0-9]+)[/]?/);
+useRoute(/^[/](?<word>[a-z]+):(?<num>[0-9]+)[/]?$/);
 ```
 
 The second item in the pair `params` is an object with parameters or null if there was no match. For wildcard segments the parameter name is `"*"`:
@@ -335,7 +335,7 @@ const User = () => {
   params[0]; // "1"
 };
 
-<Route path={/[/]user[/](?<id>[0-9]+)[/]?/} component={User}> />
+<Route path={/^[/]user[/](?<id>[0-9]+)[/]?$/} component={User}> />
 ```
 
 ### `useSearch`: query strings
@@ -442,9 +442,10 @@ If you call `useLocation()` inside the last route, it will return `/orders` and 
 </Route>
 ```
 
-**Note:** The `nest` prop has no effect on regexes passed in.
-It will only determine if nested routes will match the rest of path or match against the same path.
-To make a strict path regex, use regex techniques like `[/]?$` (this matches an optional end slash and the end of the string).
+**Note:** The `nest` prop does not alter the regex passed into regex paths.
+Instead, the `nest` prop will only determine if nested routes will match against the rest of path or the same path.
+To make a strict path regex, use a regex pattern like `/^[/](your pattern)[/]?$/` (this matches an optional end slash and the end of the string).
+To make a nestable regex, use a regex pattern like `/^[/](your pattern)(?=$|[/])/` (this matches either the end of the string or a slash for future segments).
 
 ### `<Link href={path} />`
 

--- a/README.md
+++ b/README.md
@@ -318,12 +318,15 @@ const User = () => {
   const params = useParams();
 
   params.id; // "1"
+
+  // alternatively, use the index to access the prop
+  params[0]; // "1"
 };
 
 <Route path="/user/:id" component={User}> />
 ```
 
-For regex paths, parameters are accessible as indices or through their group name.
+It is the same for regex paths. Capture groups can be accessed by their index, or if there is a named capture group, that can be used instead.
 
 ```js
 import { Route, useParams } from "wouter";

--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ useRoute("/app*");
 // optional wildcards, matches "/orders", "/orders/"
 // and "/orders/completed/list"
 useRoute("/orders/*?");
+
+// regex for matching complex patterns,
+// matches "/hello:123"
+useRoute(/[/]([a-z]+):([0-9]+)[/]?/);
+// and with named capture groups
+useRoute(/[/](?<word>[a-z]+):(?<num>[0-9]+)[/]?/);
 ```
 
 The second item in the pair `params` is an object with parameters or null if there was no match. For wildcard segments the parameter name is `"*"`:
@@ -315,6 +321,21 @@ const User = () => {
 };
 
 <Route path="/user/:id" component={User}> />
+```
+
+For regex paths, parameters are accessible as indices or through their group name.
+
+```js
+import { Route, useParams } from "wouter";
+
+const User = () => {
+  const params = useParams();
+
+  params.id; // "1"
+  params[0]; // "1"
+};
+
+<Route path={/[/]user[/](?<id>[0-9]+)[/]?/} component={User}> />
 ```
 
 ### `useSearch`: query strings
@@ -420,6 +441,10 @@ If you call `useLocation()` inside the last route, it will return `/orders` and 
   </Route>
 </Route>
 ```
+
+**Note:** The `nest` prop has no effect on regexes passed in.
+It will only determine if nested routes will match the rest of path or match against the same path.
+To make a strict path regex, use regex techniques like `[/]?$` (this matches an optional end slash and the end of the string).
 
 ### `<Link href={path} />`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6499,7 +6499,7 @@
       }
     },
     "packages/wouter": {
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "Unlicense",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -6511,7 +6511,7 @@
       }
     },
     "packages/wouter-preact": {
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "Unlicense",
       "dependencies": {
         "mitt": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "packages/wouter-preact"
   ],
   "scripts": {
-    "fix:p": "prettier --write './**/*.(js|ts){x,}'",
+    "fix:p": "prettier --write \"./**/*.(js|ts){x,}\"",
     "test": "vitest",
     "size": "size-limit",
     "build": "npm run build -ws",

--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -10,6 +10,7 @@ import {
 
 import {
   Path,
+  PathPattern,
   BaseLocationHook,
   HookReturnValue,
   HookNavigationOptions,
@@ -59,7 +60,7 @@ export interface RouteComponentProps<T extends DefaultParams = DefaultParams> {
 
 export interface RouteProps<
   T extends DefaultParams | undefined = undefined,
-  RoutePath extends Path | RegExp = Path | RegExp
+  RoutePath extends PathPattern = PathPattern
 > {
   children?:
     | ((
@@ -85,7 +86,7 @@ export interface RouteProps<
 
 export function Route<
   T extends DefaultParams | undefined = undefined,
-  RoutePath extends Path | RegExp = Path | RegExp
+  RoutePath extends PathPattern = PathPattern
 >(props: RouteProps<T, RoutePath>): ReturnType<FunctionComponent>;
 
 /*
@@ -155,7 +156,7 @@ export function useRouter(): RouterObject;
 
 export function useRoute<
   T extends DefaultParams | undefined = undefined,
-  RoutePath extends Path | RegExp = Path | RegExp
+  RoutePath extends PathPattern = PathPattern
 >(
   pattern: RoutePath
 ): Match<

--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -30,6 +30,9 @@ export * from "./router.js";
 
 import { RouteParams } from "regexparam";
 
+export type StringRouteParams<T extends string> = RouteParams<T> & {
+  [param: number]: string | undefined;
+};
 export type RegexRouteParams = { [key: string | number]: string | undefined };
 
 /**
@@ -67,7 +70,7 @@ export interface RouteProps<
         params: T extends DefaultParams
           ? T
           : RoutePath extends string
-          ? RouteParams<RoutePath>
+          ? StringRouteParams<RoutePath>
           : RegexRouteParams
       ) => ComponentChildren)
     | ComponentChildren;
@@ -77,7 +80,7 @@ export interface RouteProps<
       T extends DefaultParams
         ? T
         : RoutePath extends string
-        ? RouteParams<RoutePath>
+        ? StringRouteParams<RoutePath>
         : RegexRouteParams
     >
   >;
@@ -163,7 +166,7 @@ export function useRoute<
   T extends DefaultParams
     ? T
     : RoutePath extends string
-    ? RouteParams<RoutePath>
+    ? StringRouteParams<RoutePath>
     : RegexRouteParams
 >;
 
@@ -176,7 +179,7 @@ export function useSearch<
 >(): ReturnType<H>;
 
 export function useParams<T = undefined>(): T extends string
-  ? RouteParams<T>
+  ? StringRouteParams<T>
   : T extends undefined
   ? DefaultParams
   : T;

--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -29,11 +29,13 @@ export * from "./router.js";
 
 import { RouteParams } from "regexparam";
 
+export type RegexRouteParams = { [key: string | number]: string | undefined };
+
 /**
  * Route patterns and parameters
  */
 export interface DefaultParams {
-  readonly [paramName: string]: string | undefined;
+  readonly [paramName: string | number]: string | undefined;
 }
 
 export type Params<T extends DefaultParams = DefaultParams> = T;
@@ -57,23 +59,33 @@ export interface RouteComponentProps<T extends DefaultParams = DefaultParams> {
 
 export interface RouteProps<
   T extends DefaultParams | undefined = undefined,
-  RoutePath extends Path = Path
+  RoutePath extends Path | RegExp = Path | RegExp
 > {
   children?:
     | ((
-        params: T extends DefaultParams ? T : RouteParams<RoutePath>
+        params: T extends DefaultParams
+          ? T
+          : RoutePath extends string
+          ? RouteParams<RoutePath>
+          : RegexRouteParams
       ) => ComponentChildren)
     | ComponentChildren;
   path?: RoutePath;
   component?: ComponentType<
-    RouteComponentProps<T extends DefaultParams ? T : RouteParams<RoutePath>>
+    RouteComponentProps<
+      T extends DefaultParams
+        ? T
+        : RoutePath extends string
+        ? RouteParams<RoutePath>
+        : RegexRouteParams
+    >
   >;
   nest?: boolean;
 }
 
 export function Route<
   T extends DefaultParams | undefined = undefined,
-  RoutePath extends Path = Path
+  RoutePath extends Path | RegExp = Path | RegExp
 >(props: RouteProps<T, RoutePath>): ReturnType<FunctionComponent>;
 
 /*
@@ -143,10 +155,16 @@ export function useRouter(): RouterObject;
 
 export function useRoute<
   T extends DefaultParams | undefined = undefined,
-  RoutePath extends Path = Path
+  RoutePath extends Path | RegExp = Path | RegExp
 >(
   pattern: RoutePath
-): Match<T extends DefaultParams ? T : RouteParams<RoutePath>>;
+): Match<
+  T extends DefaultParams
+    ? T
+    : RoutePath extends string
+    ? RouteParams<RoutePath>
+    : RegexRouteParams
+>;
 
 export function useLocation<
   H extends BaseLocationHook = BrowserLocationHook

--- a/packages/wouter-preact/types/location-hook.d.ts
+++ b/packages/wouter-preact/types/location-hook.d.ts
@@ -4,6 +4,8 @@
 
 export type Path = string;
 
+export type PathPattern = string | RegExp;
+
 export type SearchString = string;
 
 // the base useLocation hook type. Any custom hook (including the

--- a/packages/wouter-preact/types/router.d.ts
+++ b/packages/wouter-preact/types/router.d.ts
@@ -5,7 +5,10 @@ import {
   BaseSearchHook,
 } from "./location-hook.js";
 
-export type Parser = (route: Path) => { pattern: RegExp; keys: string[] };
+export type Parser = (
+  route: Path | RegExp,
+  loose?: boolean
+) => { pattern: RegExp; keys: string[] };
 
 export type HrefsFormatter = (href: string, router: RouterObject) => string;
 

--- a/packages/wouter-preact/types/router.d.ts
+++ b/packages/wouter-preact/types/router.d.ts
@@ -6,7 +6,7 @@ import {
 } from "./location-hook.js";
 
 export type Parser = (
-  route: Path | RegExp,
+  route: Path,
   loose?: boolean
 ) => { pattern: RegExp; keys: string[] };
 

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -80,12 +80,10 @@ export const useSearch = () => {
 
 const matchRoute = (parser, route, path, loose) => {
   // if the input is a regexp, skip parsing
-  const { pattern, keys } = (() => {
-    if (route instanceof RegExp) {
-      return { keys: false, pattern: route };
-    }
-    return parser(route || "*", loose);
-  })();
+  const { pattern, keys } =
+    route instanceof RegExp
+      ? { keys: false, pattern: route }
+      : parser(route || "*", loose);
 
   // array destructuring loses keys, so this is done in two steps
   const result = pattern.exec(path) || [];

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -79,15 +79,21 @@ export const useSearch = () => {
 };
 
 const matchRoute = (parser, route, path, loose) => {
-  // if the route is a regex, `loose` is ignored and
+  // if the input is a regexp, skip parsing
+  const { pattern, keys } = (() => {
+    if (route instanceof RegExp) {
+      return { keys: false, pattern: route };
+    }
+    return parser(route || "*", loose);
+  })();
+
+  // array destructuring loses keys, so this is done in two steps
+  const result = pattern.exec(path) || [];
 
   // when parser is in "loose" mode, `$base` is equal to the
   // first part of the route that matches the pattern
   // (e.g. for pattern `/a/:b` and path `/a/1/2/3` the `$base` is `a/1`)
   // we use this for route nesting
-  const { pattern, keys } = parser(route || "*", loose);
-  // array destructuring loses keys, so this is done in two steps
-  const result = pattern.exec(path) || [];
   const [$base, ...matches] = result;
 
   return $base !== undefined

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -99,20 +99,22 @@ const matchRoute = (parser, route, path, loose) => {
         true,
 
         (() => {
-          /// for regex paths, `keys` will always be false
-          if (keys !== false) {
-            // an object with parameters matched, e.g. { foo: "bar" } for "/:foo"
-            // we "zip" two arrays here to construct the object
-            // ["foo"], ["bar"] → { foo: "bar" }
-            return Object.fromEntries(keys.map((key, i) => [key, matches[i]]));
-          }
+          // for regex paths, `keys` will always be false
+
+          // an object with parameters matched, e.g. { foo: "bar" } for "/:foo"
+          // we "zip" two arrays here to construct the object
+          // ["foo"], ["bar"] → { foo: "bar" }
+          const groups =
+            keys !== false
+              ? Object.fromEntries(keys.map((key, i) => [key, matches[i]]))
+              : result.groups;
 
           // convert the array to an instance of object
           // this makes it easier to integrate with the existing param implementation
           let obj = { ...matches };
 
           // merge named capture groups with matches array
-          result.groups && Object.assign(obj, result.groups);
+          groups && Object.assign(obj, groups);
 
           return obj;
         })(),

--- a/packages/wouter/test/parser.test.tsx
+++ b/packages/wouter/test/parser.test.tsx
@@ -7,7 +7,7 @@ import { Router, useRouter, useRoute, Parser } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 
 // Custom parser that uses `path-to-regexp` instead of `regexparam`
-const pathToRegexpParser: Parser = (route: string | RegExp) => {
+const pathToRegexpParser: Parser = (route: string) => {
   const keys: Key[] = [];
   const pattern = pathToRegexp(route, keys);
 
@@ -42,6 +42,6 @@ it("allows to change the behaviour of route matching", () => {
 
   expect(result.current).toStrictEqual([
     true,
-    { pages: undefined, rest: "10/bio", 0: "home" },
+    { 0: "home", 1: undefined, 2: "10/bio", pages: undefined, rest: "10/bio" },
   ]);
 });

--- a/packages/wouter/test/parser.test.tsx
+++ b/packages/wouter/test/parser.test.tsx
@@ -7,7 +7,7 @@ import { Router, useRouter, useRoute, Parser } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 
 // Custom parser that uses `path-to-regexp` instead of `regexparam`
-const pathToRegexpParser: Parser = (route: string) => {
+const pathToRegexpParser: Parser = (route: string | RegExp) => {
   const keys: Key[] = [];
   const pattern = pathToRegexp(route, keys);
 

--- a/packages/wouter/test/route.test-d.tsx
+++ b/packages/wouter/test/route.test-d.tsx
@@ -8,9 +8,9 @@ describe("`path` prop", () => {
     assertType(<Route />);
   });
 
-  it("should be a string", () => {
+  it("should be a string or RegExp", () => {
     let a: ComponentProps<typeof Route>["path"];
-    expectTypeOf(a).toMatchTypeOf<string | undefined>();
+    expectTypeOf(a).toMatchTypeOf<string | RegExp | undefined>();
   });
 });
 

--- a/packages/wouter/test/route.test.tsx
+++ b/packages/wouter/test/route.test.tsx
@@ -95,3 +95,47 @@ it("supports `base` routers with relative path", () => {
 
   unmount();
 });
+
+it("supports `path` prop with regex", () => {
+  const result = testRouteRender(
+    "/foo",
+    <Route path={/[/]foo/}>
+      <h1>Hello!</h1>
+    </Route>
+  );
+
+  expect(result.findByType("h1").props.children).toBe("Hello!");
+});
+
+it("supports regex path named params", () => {
+  const result = testRouteRender(
+    "/users/alex",
+    <Route path={/[/]users[/](?<name>[a-z]+)/}>
+      {(params) => <h1>{params.name}</h1>}
+    </Route>
+  );
+
+  expect(result.findByType("h1").props.children).toBe("alex");
+});
+
+it("supports regex path anonymous params", () => {
+  const result = testRouteRender(
+    "/users/alex",
+    <Route path={/[/]users[/]([a-z]+)/}>
+      {(params) => <h1>{params[0]}</h1>}
+    </Route>
+  );
+
+  expect(result.findByType("h1").props.children).toBe("alex");
+});
+
+it("rejects when a path does not match the regex", () => {
+  const result = testRouteRender(
+    "/users/1234",
+    <Route path={/[/]users[/](?<name>[a-z]+)/}>
+      {(params) => <h1>{params.name}</h1>}
+    </Route>
+  );
+
+  expect(() => result.findByType("h1")).toThrow();
+});

--- a/packages/wouter/test/router.test-d.tsx
+++ b/packages/wouter/test/router.test-d.tsx
@@ -1,6 +1,13 @@
 import { ComponentProps } from "react";
 import { it, expectTypeOf } from "vitest";
-import { Router, Route, BaseLocationHook, useRouter } from "wouter";
+import {
+  Router,
+  Route,
+  BaseLocationHook,
+  useRouter,
+  Parser,
+  Path,
+} from "wouter";
 
 it("should have at least one child", () => {
   // @ts-expect-error
@@ -62,6 +69,17 @@ it("accepts `hrefs` function for transforming href strings", () => {
   >
     routers as a second argument
   </Router>;
+});
+
+it("accepts `parser` function for generating regular expressions", () => {
+  const parser: Parser = (path: Path, loose?: boolean) => {
+    return {
+      pattern: new RegExp(`^${path}${loose === true ? "(?=$|[/])" : "[/]$"}`),
+      keys: [],
+    };
+  };
+
+  <Router parser={parser}>this is a valid router</Router>;
 });
 
 it("does not accept other props", () => {

--- a/packages/wouter/test/use-params.test-d.ts
+++ b/packages/wouter/test/use-params.test-d.ts
@@ -10,12 +10,18 @@ it("returns an object with arbitrary parameters", () => {
 
   expectTypeOf(params).toBeObject();
   expectTypeOf(params.any).toEqualTypeOf<string | undefined>();
+  expectTypeOf(params[0]).toEqualTypeOf<string | undefined>();
 });
 
 it("can infer the type of parameters from the route path", () => {
   const params = useParams<"/app/users/:name?/:id">();
 
-  expectTypeOf(params).toMatchTypeOf<{ id: string; name?: string }>();
+  expectTypeOf(params).toMatchTypeOf<{
+    0?: string;
+    1?: string;
+    id: string;
+    name?: string;
+  }>();
 });
 
 it("can accept the custom type of parameters as a generic argument", () => {

--- a/packages/wouter/test/use-params.test.tsx
+++ b/packages/wouter/test/use-params.test.tsx
@@ -18,7 +18,10 @@ it("contains a * parameter when used inside an empty <Route />", () => {
     ),
   });
 
-  expect(result.current).toEqual({ "*": "app-2/goods/tees" });
+  expect(result.current).toEqual({
+    0: "app-2/goods/tees",
+    "*": "app-2/goods/tees",
+  });
 });
 
 it("returns an empty object when there are no params", () => {
@@ -40,7 +43,12 @@ it("returns parameters from the closest parent <Route /> match", () => {
     ),
   });
 
-  expect(result.current).toEqual({ id: "1", name: "maria" });
+  expect(result.current).toEqual({
+    0: "1",
+    1: "maria",
+    id: "1",
+    name: "maria",
+  });
 });
 
 it("rerenders with parameters change", () => {
@@ -57,10 +65,20 @@ it("rerenders with parameters change", () => {
   expect(result.current).toBeNull();
 
   act(() => navigate("/posts/all"));
-  expect(result.current).toEqual({ a: "posts", b: "all" });
+  expect(result.current).toEqual({
+    0: "posts",
+    1: "all",
+    a: "posts",
+    b: "all",
+  });
 
   act(() => navigate("/posts/latest"));
-  expect(result.current).toEqual({ a: "posts", b: "latest" });
+  expect(result.current).toEqual({
+    0: "posts",
+    1: "latest",
+    a: "posts",
+    b: "latest",
+  });
 });
 
 it("extracts parameters of the nested route", () => {
@@ -79,5 +97,10 @@ it("extracts parameters of the nested route", () => {
     ),
   });
 
-  expect(result.current).toEqual({ version: "v2", chain: "eth" });
+  expect(result.current).toEqual({
+    0: "v2",
+    1: "eth",
+    version: "v2",
+    chain: "eth",
+  });
 });

--- a/packages/wouter/test/use-route.test-d.ts
+++ b/packages/wouter/test/use-route.test-d.ts
@@ -40,6 +40,9 @@ it("infers parameters from the route path", () => {
 
   if (inferedParams) {
     expectTypeOf(inferedParams).toMatchTypeOf<{
+      0?: string;
+      1?: string;
+      2?: string;
       name?: string;
       id: string;
       wildcard?: string;

--- a/packages/wouter/test/use-route.test.tsx
+++ b/packages/wouter/test/use-route.test.tsx
@@ -6,21 +6,24 @@ import { memoryLocation } from "wouter/memory-location";
 it("is case insensitive", () => {
   assertRoute("/Users", "/users", {});
   assertRoute("/HomePage", "/Homepage", {});
-  assertRoute("/Users/:Name", "/users/alex", { Name: "alex" });
+  assertRoute("/Users/:Name", "/users/alex", { 0: "alex", Name: "alex" });
 });
 
 it("supports required segments", () => {
-  assertRoute("/:page", "/users", { page: "users" });
+  assertRoute("/:page", "/users", { 0: "users", page: "users" });
   assertRoute("/:page", "/users/all", false);
-  assertRoute("/:page", "/1", { page: "1" });
+  assertRoute("/:page", "/1", { 0: "1", page: "1" });
 
-  assertRoute("/home/:page/etc", "/home/users/etc", { page: "users" });
+  assertRoute("/home/:page/etc", "/home/users/etc", {
+    0: "users",
+    page: "users",
+  });
   assertRoute("/home/:page/etc", "/home/etc", false);
 
   assertRoute(
     "/root/payments/:id/refunds/:refId",
     "/root/payments/1/refunds/2",
-    [true, { id: "1", refId: "2" }]
+    [true, { 0: "1", 1: "2", id: "1", refId: "2" }]
   );
 });
 
@@ -31,22 +34,41 @@ it("ignores the trailing slash", () => {
   assertRoute("/home/", "/home/", {});
   assertRoute("/home/", "/home", {});
 
-  assertRoute("/:page", "/users/", [true, { page: "users" }]);
-  assertRoute("/catalog/:section?", "/catalog/", { section: undefined });
+  assertRoute("/:page", "/users/", [true, { 0: "users", page: "users" }]);
+  assertRoute("/catalog/:section?", "/catalog/", {
+    0: undefined,
+    section: undefined,
+  });
 });
 
 it("supports trailing wildcards", () => {
-  assertRoute("/app/*", "/app/", { "*": "" });
-  assertRoute("/app/*", "/app/dashboard/intro", { "*": "dashboard/intro" });
-  assertRoute("/app/*", "/app/charges/1", { "*": "charges/1" });
+  assertRoute("/app/*", "/app/", { 0: "", "*": "" });
+  assertRoute("/app/*", "/app/dashboard/intro", {
+    0: "dashboard/intro",
+    "*": "dashboard/intro",
+  });
+  assertRoute("/app/*", "/app/charges/1", { 0: "charges/1", "*": "charges/1" });
 });
 
 it("supports wildcards in the middle of the pattern", () => {
-  assertRoute("/app/*/settings", "/app/users/settings", { "*": "users" });
-  assertRoute("/app/*/settings", "/app/users/1/settings", { "*": "users/1" });
+  assertRoute("/app/*/settings", "/app/users/settings", {
+    0: "users",
+    "*": "users",
+  });
+  assertRoute("/app/*/settings", "/app/users/1/settings", {
+    0: "users/1",
+    "*": "users/1",
+  });
 
-  assertRoute("/*/payments/:id", "/home/payments/1", { "*": "home", id: "1" });
+  assertRoute("/*/payments/:id", "/home/payments/1", {
+    0: "home",
+    1: "1",
+    "*": "home",
+    id: "1",
+  });
   assertRoute("/*/payments/:id?", "/home/payments", {
+    0: "home",
+    1: undefined,
     "*": "home",
     id: undefined,
   });
@@ -54,56 +76,78 @@ it("supports wildcards in the middle of the pattern", () => {
 
 it("uses a question mark to define optional segments", () => {
   assertRoute("/books/:genre/:title?", "/books/scifi", {
+    0: "scifi",
+    1: undefined,
     genre: "scifi",
     title: undefined,
   });
   assertRoute("/books/:genre/:title?", "/books/scifi/dune", {
+    0: "scifi",
+    1: "dune",
     genre: "scifi",
     title: "dune",
   });
   assertRoute("/books/:genre/:title?", "/books/scifi/dune/all", false);
 
   assertRoute("/app/:company?/blog/:post", "/app/apple/blog/mac", {
+    0: "apple",
+    1: "mac",
     company: "apple",
     post: "mac",
   });
 
   assertRoute("/app/:company?/blog/:post", "/app/blog/mac", {
+    0: undefined,
+    1: "mac",
     company: undefined,
     post: "mac",
   });
 });
 
 it("supports optional wildcards", () => {
-  assertRoute("/app/*?", "/app/blog/mac", { "*": "blog/mac" });
-  assertRoute("/app/*?", "/app", { "*": undefined });
-  assertRoute("/app/*?/dashboard", "/app/v1/dashboard", { "*": "v1" });
-  assertRoute("/app/*?/dashboard", "/app/dashboard", { "*": undefined });
+  assertRoute("/app/*?", "/app/blog/mac", { 0: "blog/mac", "*": "blog/mac" });
+  assertRoute("/app/*?", "/app", { 0: undefined, "*": undefined });
+  assertRoute("/app/*?/dashboard", "/app/v1/dashboard", { 0: "v1", "*": "v1" });
+  assertRoute("/app/*?/dashboard", "/app/dashboard", {
+    0: undefined,
+    "*": undefined,
+  });
   assertRoute("/app/*?/users/:name", "/app/users/karen", {
+    0: undefined,
+    1: "karen",
     "*": undefined,
     name: "karen",
   });
 });
 
 it("supports other characters in segments", () => {
-  assertRoute("/users/:name", "/users/1-alex", { name: "1-alex" });
+  assertRoute("/users/:name", "/users/1-alex", { 0: "1-alex", name: "1-alex" });
   assertRoute("/staff/:name/:bio?", "/staff/John Doe 3", {
+    0: "John Doe 3",
+    1: undefined,
     name: "John Doe 3",
     bio: undefined,
   });
   assertRoute("/staff/:name/:bio?", "/staff/John Doe 3/bio", {
+    0: "John Doe 3",
+    1: "bio",
     name: "John Doe 3",
     bio: "bio",
   });
 
   assertRoute("/users/:name/bio", "/users/$102_Kathrine&/bio", {
+    0: "$102_Kathrine&",
     name: "$102_Kathrine&",
   });
 });
 
 it("ignores escaped slashes", () => {
-  assertRoute("/:param/bar", "/foo%2Fbar/bar", { param: "foo%2Fbar" });
+  assertRoute("/:param/bar", "/foo%2Fbar/bar", {
+    0: "foo%2Fbar",
+    param: "foo%2Fbar",
+  });
   assertRoute("/:param", "/foo%2Fbar%D1%81%D0%B0%D0%BD%D1%8F", {
+    0: "foo%2Fbarсаня",
     param: "foo%2Fbarсаня",
   });
 });
@@ -138,17 +182,27 @@ it("reacts to pattern updates", () => {
   rerender({ pattern: "/blog/:category/:post/:action" });
   expect(result.current).toStrictEqual([
     true,
-    { category: "products", post: "40", action: "read-all" },
+    {
+      0: "products",
+      1: "40",
+      2: "read-all",
+      category: "products",
+      post: "40",
+      action: "read-all",
+    },
   ]);
 
   rerender({ pattern: "/blog/products/:id?/read-all" });
-  expect(result.current).toStrictEqual([true, { id: "40" }]);
+  expect(result.current).toStrictEqual([true, { 0: "40", id: "40" }]);
 
   rerender({ pattern: "/blog/products/:name" });
   expect(result.current).toStrictEqual([false, null]);
 
   rerender({ pattern: "/blog/*" });
-  expect(result.current).toStrictEqual([true, { "*": "products/40/read-all" }]);
+  expect(result.current).toStrictEqual([
+    true,
+    { 0: "products/40/read-all", "*": "products/40/read-all" },
+  ]);
 });
 
 it("reacts to location updates", () => {
@@ -161,16 +215,19 @@ it("reacts to location updates", () => {
   expect(result.current).toStrictEqual([false, null]);
 
   act(() => navigate("/cities/berlin"));
-  expect(result.current).toStrictEqual([true, { city: "berlin" }]);
+  expect(result.current).toStrictEqual([true, { 0: "berlin", city: "berlin" }]);
 
   act(() => navigate("/cities/Tokyo"));
-  expect(result.current).toStrictEqual([true, { city: "Tokyo" }]);
+  expect(result.current).toStrictEqual([true, { 0: "Tokyo", city: "Tokyo" }]);
 
   act(() => navigate("/about"));
   expect(result.current).toStrictEqual([false, null]);
 
   act(() => navigate("/cities"));
-  expect(result.current).toStrictEqual([true, { city: undefined }]);
+  expect(result.current).toStrictEqual([
+    true,
+    { 0: undefined, city: undefined },
+  ]);
 });
 
 /**

--- a/packages/wouter/test/use-route.test.tsx
+++ b/packages/wouter/test/use-route.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
-import { useRoute, Match, Router } from "wouter";
+import { useRoute, Match, Router, RegexRouteParams } from "wouter";
 import { it, expect } from "vitest";
 import { memoryLocation } from "wouter/memory-location";
 
@@ -108,6 +108,14 @@ it("ignores escaped slashes", () => {
   });
 });
 
+it("supports regex patterns", () => {
+  assertRoute(/[/]foo/, "/foo", {});
+  assertRoute(/[/]([a-z]+)/, "/bar", { 0: "bar" });
+  assertRoute(/[/]([a-z]+)/, "/123", false);
+  assertRoute(/[/](?<param>[a-z]+)/, "/bar", { 0: "bar", param: "bar" });
+  assertRoute(/[/](?<param>[a-z]+)/, "/123", false);
+});
+
 it("reacts to pattern updates", () => {
   const { result, rerender } = renderHook(
     ({ pattern }: { pattern: string }) => useRoute(pattern),
@@ -170,7 +178,7 @@ it("reacts to location updates", () => {
  */
 
 const assertRoute = (
-  pattern: string,
+  pattern: string | RegExp,
   location: string,
   rhs: false | Match | Record<string, string | undefined>
 ) => {

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -33,11 +33,13 @@ export * from "./router.js";
 
 import { RouteParams } from "regexparam";
 
+export type RegexRouteParams = { [key: string | number]: string | undefined };
+
 /**
  * Route patterns and parameters
  */
 export interface DefaultParams {
-  readonly [paramName: string]: string | undefined;
+  readonly [paramName: string | number]: string | undefined;
 }
 
 export type Params<T extends DefaultParams = DefaultParams> = T;
@@ -61,23 +63,33 @@ export interface RouteComponentProps<T extends DefaultParams = DefaultParams> {
 
 export interface RouteProps<
   T extends DefaultParams | undefined = undefined,
-  RoutePath extends Path = Path
+  RoutePath extends Path | RegExp = Path | RegExp
 > {
   children?:
     | ((
-        params: T extends DefaultParams ? T : RouteParams<RoutePath>
+        params: T extends DefaultParams
+          ? T
+          : RoutePath extends string
+          ? RouteParams<RoutePath>
+          : RegexRouteParams
       ) => ReactNode)
     | ReactNode;
   path?: RoutePath;
   component?: ComponentType<
-    RouteComponentProps<T extends DefaultParams ? T : RouteParams<RoutePath>>
+    RouteComponentProps<
+      T extends DefaultParams
+        ? T
+        : RoutePath extends string
+        ? RouteParams<RoutePath>
+        : RegexRouteParams
+    >
   >;
   nest?: boolean;
 }
 
 export function Route<
   T extends DefaultParams | undefined = undefined,
-  RoutePath extends Path = Path
+  RoutePath extends Path | RegExp = Path | RegExp
 >(props: RouteProps<T, RoutePath>): ReturnType<FunctionComponent>;
 
 /*
@@ -150,10 +162,16 @@ export function useRouter(): RouterObject;
 
 export function useRoute<
   T extends DefaultParams | undefined = undefined,
-  RoutePath extends Path = Path
+  RoutePath extends Path | RegExp = Path | RegExp
 >(
   pattern: RoutePath
-): Match<T extends DefaultParams ? T : RouteParams<RoutePath>>;
+): Match<
+  T extends DefaultParams
+    ? T
+    : RoutePath extends string
+    ? RouteParams<RoutePath>
+    : RegexRouteParams
+>;
 
 export function useLocation<
   H extends BaseLocationHook = BrowserLocationHook

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -14,6 +14,7 @@ import {
 
 import {
   Path,
+  PathPattern,
   BaseLocationHook,
   HookReturnValue,
   HookNavigationOptions,
@@ -63,7 +64,7 @@ export interface RouteComponentProps<T extends DefaultParams = DefaultParams> {
 
 export interface RouteProps<
   T extends DefaultParams | undefined = undefined,
-  RoutePath extends Path | RegExp = Path | RegExp
+  RoutePath extends PathPattern = PathPattern
 > {
   children?:
     | ((
@@ -89,7 +90,7 @@ export interface RouteProps<
 
 export function Route<
   T extends DefaultParams | undefined = undefined,
-  RoutePath extends Path | RegExp = Path | RegExp
+  RoutePath extends PathPattern = PathPattern
 >(props: RouteProps<T, RoutePath>): ReturnType<FunctionComponent>;
 
 /*
@@ -162,7 +163,7 @@ export function useRouter(): RouterObject;
 
 export function useRoute<
   T extends DefaultParams | undefined = undefined,
-  RoutePath extends Path | RegExp = Path | RegExp
+  RoutePath extends PathPattern = PathPattern
 >(
   pattern: RoutePath
 ): Match<

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -34,6 +34,9 @@ export * from "./router.js";
 
 import { RouteParams } from "regexparam";
 
+export type StringRouteParams<T extends string> = RouteParams<T> & {
+  [param: number]: string | undefined;
+};
 export type RegexRouteParams = { [key: string | number]: string | undefined };
 
 /**
@@ -71,7 +74,7 @@ export interface RouteProps<
         params: T extends DefaultParams
           ? T
           : RoutePath extends string
-          ? RouteParams<RoutePath>
+          ? StringRouteParams<RoutePath>
           : RegexRouteParams
       ) => ReactNode)
     | ReactNode;
@@ -81,7 +84,7 @@ export interface RouteProps<
       T extends DefaultParams
         ? T
         : RoutePath extends string
-        ? RouteParams<RoutePath>
+        ? StringRouteParams<RoutePath>
         : RegexRouteParams
     >
   >;
@@ -170,7 +173,7 @@ export function useRoute<
   T extends DefaultParams
     ? T
     : RoutePath extends string
-    ? RouteParams<RoutePath>
+    ? StringRouteParams<RoutePath>
     : RegexRouteParams
 >;
 
@@ -183,7 +186,7 @@ export function useSearch<
 >(): ReturnType<H>;
 
 export function useParams<T = undefined>(): T extends string
-  ? RouteParams<T>
+  ? StringRouteParams<T>
   : T extends undefined
   ? DefaultParams
   : T;

--- a/packages/wouter/types/location-hook.d.ts
+++ b/packages/wouter/types/location-hook.d.ts
@@ -4,6 +4,8 @@
 
 export type Path = string;
 
+export type PathPattern = string | RegExp;
+
 export type SearchString = string;
 
 // the base useLocation hook type. Any custom hook (including the

--- a/packages/wouter/types/router.d.ts
+++ b/packages/wouter/types/router.d.ts
@@ -5,7 +5,10 @@ import {
   BaseSearchHook,
 } from "./location-hook.js";
 
-export type Parser = (route: Path | RegExp, loose?: boolean) => { pattern: RegExp; keys: string[] };
+export type Parser = (
+  route: Path | RegExp,
+  loose?: boolean
+) => { pattern: RegExp; keys: string[] };
 
 export type HrefsFormatter = (href: string, router: RouterObject) => string;
 

--- a/packages/wouter/types/router.d.ts
+++ b/packages/wouter/types/router.d.ts
@@ -5,7 +5,7 @@ import {
   BaseSearchHook,
 } from "./location-hook.js";
 
-export type Parser = (route: Path) => { pattern: RegExp; keys: string[] };
+export type Parser = (route: Path | RegExp, loose?: boolean) => { pattern: RegExp; keys: string[] };
 
 export type HrefsFormatter = (href: string, router: RouterObject) => string;
 

--- a/packages/wouter/types/router.d.ts
+++ b/packages/wouter/types/router.d.ts
@@ -6,7 +6,7 @@ import {
 } from "./location-hook.js";
 
 export type Parser = (
-  route: Path | RegExp,
+  route: Path,
   loose?: boolean
 ) => { pattern: RegExp; keys: string[] };
 


### PR DESCRIPTION
This fixes #449.

By supporting regular expressions in paths, it becomes possible to lift validation out of routes and into the paths themselves.

What happens when you use a `RegExp`:
The route doesn't run the parser, but just executes the regex. After executing the regex, instead of mapping the keys and values into an object, the indices of the regex result are mapped to an object and the named groups are assigned to the object as well.

For example:
```js
// Route
/[/]([a-z]+)/
// Against "/foo", produces
{ 0: "foo" }

// Route
/[/](?<name>[a-z]+)/
// Against "/foo", produces
{ 0: "foo", name: "foo" }
```

Another thing to consider: should normal paths also expose params as indices? (so, should `/:id` become `{ 0: "foo", id: "foo" }`, instead of just `{ id: "foo" }`?)