### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Adds a `.gitattributes` file to fix issues with line endings.

On Windows, many developers enable `core.autocrlf`, which converts line endings to CRLF.
Prettier converts line endings to LF by default, so this shows up as empty changes.
By specifying a `.gitattributes` file, autocrlf can be disabled per repository.

Fixes #451 