### PR TITLE
Feat: nested params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6503,7 +6503,7 @@
       }
     },
     "packages/wouter": {
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "Unlicense",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -6515,7 +6515,7 @@
       }
     },
     "packages/wouter-preact": {
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "Unlicense",
       "dependencies": {
         "mitt": "^3.0.1",

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -194,13 +194,27 @@ const h_route = ({ children, component }, params) => {
 export const Route = ({ path, nest, match, ...renderProps }) => {
   const router = useRouter();
   const [location] = useLocationFromRouter(router);
+  const parentParams = useParams();
 
-  const [matches, params, base] =
+  const [matches, routeParams, base] =
     // `match` is a special prop to give up control to the parent,
     // it is used by the `Switch` to avoid double matching
     match ?? matchRoute(router.parser, path, location, nest);
 
   if (!matches) return null;
+
+  // Implement param inheritance and overriding
+  const params = Object.entries(parentParams).reduce((acc, [key, value]) => {
+    if (typeof value === "string") {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+
+  // Override with route params
+  Object.entries(routeParams).forEach(([key, value]) => {
+    params[key] = value;
+  });
 
   const children = base
     ? h(Router, { base }, h_route(renderProps, params))

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -210,6 +210,9 @@ export const Route = ({ path, nest, match, ...renderProps }) => {
     // it is used by the `Switch` to avoid double matching
     match ?? matchRoute(router.parser, path, location, nest);
 
+  // when `routeParams` is `null` (there was no match), the argument
+  // below becomes {...null} = {}, see the Object Spread specs
+  // https://tc39.es/proposal-object-rest-spread/#AbstractOperations-CopyDataProperties
   const params = useCachedParams({ ...useParams(), ...routeParams });
 
   if (!matches) return null;

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -192,10 +192,13 @@ const h_route = ({ children, component }, params) => {
   return typeof children === "function" ? children(params) : children;
 };
 
-const useCachedParams = (value, comp = JSON.stringify) => {
-  const prev = useRef(Params0);
-  return (prev.current =
-    comp(value) === comp(prev.current) ? prev.current : value);
+// a hook to cache the params object between renders (if they are shallow equal)
+const useCachedParams = (value) => {
+  let prev = useRef(Params0),
+    curr = prev.current;
+
+  for (const k in value) if (value[k] !== curr[k]) curr = value;
+  return (prev.current = curr);
 };
 
 export const Route = ({ path, nest, match, ...renderProps }) => {
@@ -208,6 +211,7 @@ export const Route = ({ path, nest, match, ...renderProps }) => {
     match ?? matchRoute(router.parser, path, location, nest);
 
   const params = useCachedParams({ ...useParams(), ...routeParams });
+
   if (!matches) return null;
 
   const children = base

--- a/packages/wouter/test/use-params.test.tsx
+++ b/packages/wouter/test/use-params.test.tsx
@@ -32,7 +32,7 @@ it("returns an empty object when there are no params", () => {
   expect(result.current).toEqual({});
 });
 
-it("returns parameters from the closest parent <Route /> match", () => {
+it("contains parameters from the closest parent <Route />", () => {
   const { result } = renderHook(() => useParams(), {
     wrapper: (props) => (
       <Router hook={memoryLocation({ path: "/app/users/1/maria" }).hook}>
@@ -43,11 +43,40 @@ it("returns parameters from the closest parent <Route /> match", () => {
     ),
   });
 
-  expect(result.current).toEqual({
+  expect(result.current).toMatchObject({
     0: "1",
     1: "maria",
     id: "1",
     name: "maria",
+  });
+});
+
+it("inherits parameters from parent nested routes", () => {
+  const { result } = renderHook(() => useParams(), {
+    wrapper: (props) => (
+      <Router
+        hook={
+          memoryLocation({ path: "/dash/users/10/alex/bio/john/summary-1" })
+            .hook
+        }
+      >
+        <Route path="/:page" nest>
+          <Route path="/users/:id/:name" nest>
+            <Route path="/bio/:name/*">{props.children}</Route>
+          </Route>
+        </Route>
+      </Router>
+    ),
+  });
+
+  expect(result.current).toMatchObject({
+    name: "john", // name gets overriden
+    "*": "summary-1",
+    page: "dash",
+    id: "10",
+    // number params are overriden
+    0: "john",
+    1: "summary-1",
   });
 });
 

--- a/packages/wouter/test/use-params.test.tsx
+++ b/packages/wouter/test/use-params.test.tsx
@@ -149,3 +149,18 @@ it("keeps the object ref the same if params haven't changed", () => {
   rerender();
   expect(result.current).toBe(firstRenderedParams);
 });
+
+it("works when the route becomes matching", () => {
+  const { hook, navigate } = memoryLocation({ path: "/" });
+
+  const { result } = renderHook(() => useParams(), {
+    wrapper: (props) => (
+      <Router hook={hook}>
+        <Route path="/:id">{props.children}</Route>
+      </Router>
+    ),
+  });
+
+  act(() => navigate("/123"));
+  expect(result.current).toMatchObject({ id: "123" });
+});

--- a/packages/wouter/test/use-params.test.tsx
+++ b/packages/wouter/test/use-params.test.tsx
@@ -94,7 +94,7 @@ it("rerenders with parameters change", () => {
   expect(result.current).toBeNull();
 
   act(() => navigate("/posts/all"));
-  expect(result.current).toEqual({
+  expect(result.current).toMatchObject({
     0: "posts",
     1: "all",
     a: "posts",
@@ -102,7 +102,7 @@ it("rerenders with parameters change", () => {
   });
 
   act(() => navigate("/posts/latest"));
-  expect(result.current).toEqual({
+  expect(result.current).toMatchObject({
     0: "posts",
     1: "latest",
     a: "posts",
@@ -132,4 +132,20 @@ it("extracts parameters of the nested route", () => {
     version: "v2",
     chain: "eth",
   });
+});
+
+it("keeps the object ref the same if params haven't changed", () => {
+  const { hook } = memoryLocation({ path: "/foo/bar" });
+
+  const { result, rerender } = renderHook(() => useParams(), {
+    wrapper: (props) => (
+      <Router hook={hook}>
+        <Route path="/:a/:b/*?">{props.children}</Route>
+      </Router>
+    ),
+  });
+
+  const firstRenderedParams = result.current;
+  rerender();
+  expect(result.current).toBe(firstRenderedParams);
 });


### PR DESCRIPTION
Closes #409 
Parent route parameters now appear in params returned from `useParams()`. New values overwrite old ones.