### PR TITLE
Fix #478 - fixed useParams not updating issue

### DIFF
--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -198,6 +198,7 @@ const useCachedParams = (value) => {
     curr = prev.current;
 
   for (const k in value) if (value[k] !== curr[k]) curr = value;
+  if (Object.keys(value).length === 0) curr = value;
   return (prev.current = curr);
 };
 

--- a/packages/wouter/test/use-params.test.tsx
+++ b/packages/wouter/test/use-params.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { it, expect } from "vitest";
-import { useParams, Router, Route } from "wouter";
+import { useParams, Router, Route, Switch } from "wouter";
 
 import { memoryLocation } from "wouter/memory-location";
 
@@ -163,4 +163,23 @@ it("works when the route becomes matching", () => {
 
   act(() => navigate("/123"));
   expect(result.current).toMatchObject({ id: "123" });
+});
+
+it("makes the params an empty object, when there are no path params", () => {
+  const { hook, navigate } = memoryLocation({ path: "/" });
+
+  const { result } = renderHook(() => useParams(), {
+    wrapper: (props) => (
+      <Router hook={hook}>
+        <Switch>
+          <Route path="/posts">{props.children}</Route>
+          <Route path="/posts/:a">{props.children}</Route>
+        </Switch>
+      </Router>
+    ),
+  });
+
+  act(() => navigate("/posts/all"));
+  act(() => navigate("/posts"));
+  expect(Object.keys(result.current).length).toBe(0);
 });


### PR DESCRIPTION
useCachedParams hook do not update the Params0 (useRef reference) value, if the previous value is a non empty object and the current value is an empty object.

More information regarding the issue: [https://github.com/molefrog/wouter/issues/478](https://github.com/molefrog/wouter/issues/478)

Updated useCachedParams to fix this. Added a test case which tests for this behavior.  