### PR TITLE
Fix wouter link to prevent crash without href/to

### DIFF
--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -230,7 +230,7 @@ export const Link = forwardRef((props, ref) => {
   const [currentPath, navigate] = useLocationFromRouter(router);
 
   const {
-    to,
+    to = "",
     href: targetPath = to,
     onClick: _onClick,
     asChild,
@@ -265,9 +265,7 @@ export const Link = forwardRef((props, ref) => {
 
   // handle nested routers and absolute paths
   const href = router.hrefs(
-    (targetPath ?? "")[0] === "~"
-      ? targetPath.slice(1)
-      : router.base + targetPath,
+    targetPath[0] === "~" ? targetPath.slice(1) : router.base + targetPath,
     router // pass router as a second argument for convinience
   );
 

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -265,7 +265,9 @@ export const Link = forwardRef((props, ref) => {
 
   // handle nested routers and absolute paths
   const href = router.hrefs(
-    targetPath[0] === "~" ? targetPath.slice(1) : router.base + targetPath,
+    (targetPath ?? "")[0] === "~"
+      ? targetPath.slice(1)
+      : router.base + targetPath,
     router // pass router as a second argument for convinience
   );
 

--- a/packages/wouter/test/link.test.tsx
+++ b/packages/wouter/test/link.test.tsx
@@ -322,4 +322,17 @@ describe("<Link /> with `asChild` prop", () => {
     expect(link).toHaveAttribute("href", "/about");
     expect(link).toHaveTextContent("Click Me");
   });
+
+  it("missing href or to won't crash", () => {
+    const { getByText } = render(
+      /* @ts-expect-error */
+      <Link>Click Me</Link>
+    );
+
+    const link = getByText("Click Me");
+
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("href", undefined);
+    expect(link).toHaveTextContent("Click Me");
+  });
 });


### PR DESCRIPTION
`<Link />` components are mainly used together with `href` and/or `to` attributes, but there are cases where you'd only rely on the `onClick` property to navigate. In these cases, wouter crashes when it tries to check for absolute paths. 

This PR fixes it by making sure the absolute path test is pointed against a string and not undefined. 

---

(Context: I noticed this issue when using wouter together with [plasmic](https://www.plasmic.app/). Plasmic [allows to specify the link component](https://github.com/plasmicapp/plasmic/blob/master/packages/loader-react/src/PlasmicRootProvider.tsx#L121) being used to take advantage of client-side navigation. In some cases though you'd use the interactions (which is triggered inside `onClick`) to navigate in response to e.g. an API call. In these cases, wouter crashed).  