### PR TITLE
Update Parser type for optional loose arg

### DIFF
--- a/packages/wouter/types/router.d.ts
+++ b/packages/wouter/types/router.d.ts
@@ -5,7 +5,10 @@ import {
   BaseSearchHook,
 } from "./location-hook.js";
 
-export type Parser = (route: Path) => { pattern: RegExp; keys: string[] };
+export type Parser = (
+  route: Path,
+  loose?: boolean
+) => { pattern: RegExp; keys: string[] };
 
 export type HrefsFormatter = (href: string, router: RouterObject) => string;
 


### PR DESCRIPTION
Wouter _passes_ this second arg, and default parser accepts it and behaves differently when it's passed (e.g., it's needed for nested routes), so it seems useful to include in typing.