### PR TITLE
Export matchRoute

### DIFF
--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -78,7 +78,7 @@ export const useSearch = () => {
   return unescape(stripQm(router.searchHook(router)));
 };
 
-const matchRoute = (parser, route, path, loose) => {
+export const matchRoute = (parser, route, path, loose) => {
   // when parser is in "loose" mode, `$base` is equal to the
   // first part of the route that matches the pattern
   // (e.g. for pattern `/a/:b` and path `/a/1/2/3` the `$base` is `a/1`)

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -24,7 +24,7 @@ import {
   BrowserSearchHook,
 } from "./use-browser-location.js";
 
-import { RouterObject, RouterOptions } from "./router.js";
+import type { RouterObject, RouterOptions, Parser } from "./router.js";
 
 // these files only export types, so we can re-export them as-is
 // in TS 5.0 we'll be able to use `export type * from ...`
@@ -168,5 +168,19 @@ export function useParams<T = undefined>(): T extends string
   : T extends undefined
   ? DefaultParams
   : T;
+
+/*
+ * Helpers
+ */
+
+export function matchRoute<
+  T extends DefaultParams | undefined = undefined,
+  RoutePath extends Path = Path
+>(
+  parser: Parser,
+  route: RoutePath,
+  path: string,
+  exact?: boolean
+): Match<T extends DefaultParams ? T : RouteParams<RoutePath>>;
 
 // tslint:enable:no-unnecessary-generics


### PR DESCRIPTION
Please feel free to reject this suggestion, but I encountered a scenario where my routes are dynamic enough that I was building a whole `Switch`ed `Route` structure dynamically that it would just be simpler to loop over my routes and `matchRoute` directly. Easy enough to just return a single, matching `Route` I suppose (which is actually what I'm doing when `nest` is at play, since there's more stuff going on there) but it _feels_ like a code smell to me to use `Route` _after_ determining that the route matched.

What do you think? Useful? Any specific reasoning behind not exporting it? Is it just not the "React Way"?