### PR TITLE
Feat: memory location search hook

### DIFF
--- a/packages/wouter/src/memory-location.js
+++ b/packages/wouter/src/memory-location.js
@@ -7,10 +7,12 @@ import { useSyncExternalStore } from "./react-deps.js";
 
 export const memoryLocation = ({
   path = "/",
+  searchPath = "",
   static: staticLocation,
   record,
 } = {}) => {
-  let currentPath = path;
+  let currentPath = path + (searchPath && (path.split("?")[1] ? "&" : "?")) + searchPath;
+  let currentSearch = currentPath.split("?")[1] || "";
   const history = [currentPath];
   const emitter = mitt();
 
@@ -24,6 +26,7 @@ export const memoryLocation = ({
     }
 
     currentPath = path;
+    currentSearch = path.split("?")[1] || "";
     emitter.emit("navigate", path);
   };
 
@@ -39,15 +42,20 @@ export const memoryLocation = ({
     navigate,
   ];
 
+  const useMemoryQuery = () => [
+    useSyncExternalStore(subscribe, () => currentSearch)
+  ];
+
   function reset() {
     // clean history array with mutation to preserve link
     history.splice(0, history.length);
 
-    navigateImplementation(path);
+    navigateImplementation(path + (searchPath && (path.split("?")[1] ? "&" : "?")) + searchPath);
   }
 
   return {
     hook: useMemoryLocation,
+    searchHook: useMemoryQuery,
     navigate,
     history: record ? history : undefined,
     reset: record ? reset : undefined,

--- a/packages/wouter/src/memory-location.js
+++ b/packages/wouter/src/memory-location.js
@@ -18,8 +18,7 @@ export const memoryLocation = ({
     initialPath += searchPath;
   }
 
-  let currentPath = initialPath;
-  let currentSearch = currentPath.split("?")[1] || "";
+  let [currentPath, currentSearch = ""] = initialPath.split("?");
   const history = [currentPath];
   const emitter = mitt();
 
@@ -32,8 +31,7 @@ export const memoryLocation = ({
       }
     }
 
-    currentPath = path;
-    currentSearch = path.split("?")[1] || "";
+    [currentPath, currentSearch = ""] = path.split("?");
     emitter.emit("navigate", path);
   };
 

--- a/packages/wouter/src/memory-location.js
+++ b/packages/wouter/src/memory-location.js
@@ -47,9 +47,8 @@ export const memoryLocation = ({
     navigate,
   ];
 
-  const useMemoryQuery = () => [
-    useSyncExternalStore(subscribe, () => currentSearch),
-  ];
+  const useMemoryQuery = () =>
+    useSyncExternalStore(subscribe, () => currentSearch);
 
   function reset() {
     // clean history array with mutation to preserve link

--- a/packages/wouter/src/memory-location.js
+++ b/packages/wouter/src/memory-location.js
@@ -19,7 +19,7 @@ export const memoryLocation = ({
   }
 
   let [currentPath, currentSearch = ""] = initialPath.split("?");
-  const history = [currentPath];
+  const history = [initialPath];
   const emitter = mitt();
 
   const navigateImplementation = (path, { replace = false } = {}) => {

--- a/packages/wouter/src/memory-location.js
+++ b/packages/wouter/src/memory-location.js
@@ -11,7 +11,14 @@ export const memoryLocation = ({
   static: staticLocation,
   record,
 } = {}) => {
-  let currentPath = path + (searchPath && (path.split("?")[1] ? "&" : "?")) + searchPath;
+  let initialPath = path;
+  if (searchPath) {
+    // join with & if path contains search query, and ? otherwise
+    initialPath += path.split("?")[1] ? "&" : "?";
+    initialPath += searchPath;
+  }
+
+  let currentPath = initialPath;
   let currentSearch = currentPath.split("?")[1] || "";
   const history = [currentPath];
   const emitter = mitt();
@@ -43,14 +50,14 @@ export const memoryLocation = ({
   ];
 
   const useMemoryQuery = () => [
-    useSyncExternalStore(subscribe, () => currentSearch)
+    useSyncExternalStore(subscribe, () => currentSearch),
   ];
 
   function reset() {
     // clean history array with mutation to preserve link
     history.splice(0, history.length);
 
-    navigateImplementation(path + (searchPath && (path.split("?")[1] ? "&" : "?")) + searchPath);
+    navigateImplementation(initialPath);
   }
 
   return {

--- a/packages/wouter/test/memory-location.test.ts
+++ b/packages/wouter/test/memory-location.test.ts
@@ -23,6 +23,17 @@ it("should support initial path", () => {
   unmount();
 });
 
+it("should support initial path with query", () => {
+  const { searchHook } = memoryLocation({ path: "/test-case?foo=bar" });
+  // const { searchHook } = memoryLocation({ path: "/test-case", searchPath: "foo=bar" });
+
+  const { result, unmount } = renderHook(() => searchHook());
+  const [value] = result.current;
+
+  expect(value).toBe("foo=bar");
+  unmount();
+});
+
 it('should return location hook that has initial path "/" by default', () => {
   const { hook } = memoryLocation();
 
@@ -30,6 +41,16 @@ it('should return location hook that has initial path "/" by default', () => {
   const [value] = result.current;
 
   expect(value).toBe("/");
+  unmount();
+});
+
+it('should return search hook that has initial query "" by default', () => {
+  const { searchHook } = memoryLocation();
+
+  const { result, unmount } = renderHook(() => searchHook());
+  const [value] = result.current;
+
+  expect(value).toBe("");
   unmount();
 });
 

--- a/packages/wouter/test/memory-location.test.ts
+++ b/packages/wouter/test/memory-location.test.ts
@@ -27,7 +27,7 @@ it("should support initial path with query", () => {
   const { searchHook } = memoryLocation({ path: "/test-case?foo=bar" });
 
   const { result, unmount } = renderHook(() => searchHook());
-  const [value] = result.current;
+  const value = result.current;
 
   expect(value).toBe("foo=bar");
   unmount();
@@ -40,7 +40,7 @@ it("should support search path as parameter", () => {
   });
 
   const { result, unmount } = renderHook(() => searchHook());
-  const [value] = result.current;
+  const value = result.current;
 
   expect(value).toBe("foo=bar&key=value");
   unmount();
@@ -60,7 +60,7 @@ it('should return search hook that has initial query "" by default', () => {
   const { searchHook } = memoryLocation();
 
   const { result, unmount } = renderHook(() => searchHook());
-  const [value] = result.current;
+  const value = result.current;
 
   expect(value).toBe("");
   unmount();

--- a/packages/wouter/test/memory-location.test.ts
+++ b/packages/wouter/test/memory-location.test.ts
@@ -25,12 +25,24 @@ it("should support initial path", () => {
 
 it("should support initial path with query", () => {
   const { searchHook } = memoryLocation({ path: "/test-case?foo=bar" });
-  // const { searchHook } = memoryLocation({ path: "/test-case", searchPath: "foo=bar" });
 
   const { result, unmount } = renderHook(() => searchHook());
   const [value] = result.current;
 
   expect(value).toBe("foo=bar");
+  unmount();
+});
+
+it("should support search path as parameter", () => {
+  const { searchHook } = memoryLocation({
+    path: "/test-case?foo=bar",
+    searchPath: "key=value",
+  });
+
+  const { result, unmount } = renderHook(() => searchHook());
+  const [value] = result.current;
+
+  expect(value).toBe("foo=bar&key=value");
   unmount();
 });
 

--- a/packages/wouter/test/use-search.test.tsx
+++ b/packages/wouter/test/use-search.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, act } from "@testing-library/react";
 import { useSearch, Router } from "wouter";
 import { navigate } from "wouter/use-browser-location";
+import { memoryLocation } from "wouter/memory-location";
 import { it, expect, beforeEach } from "vitest";
 
 beforeEach(() => history.replaceState(null, "", "/"));
@@ -22,6 +23,18 @@ it("can be customized in the Router", () => {
   });
 
   expect(result.current).toEqual("none");
+});
+
+it("can be customized with memoryLocation", () => {
+  const { searchHook } = memoryLocation({ path: "/foo?key=value" });
+
+  const { result } = renderHook(() => useSearch(), {
+    wrapper: (props) => {
+      return <Router searchHook={searchHook}>{props.children}</Router>;
+    },
+  });
+
+  expect(result.current).toEqual("key=value");
 });
 
 it("unescapes search string", () => {

--- a/packages/wouter/test/use-search.test.tsx
+++ b/packages/wouter/test/use-search.test.tsx
@@ -37,6 +37,21 @@ it("can be customized with memoryLocation", () => {
   expect(result.current).toEqual("key=value");
 });
 
+it("can be customized with memoryLocation using search path parameter", () => {
+  const { searchHook } = memoryLocation({
+    path: "/foo?key=value",
+    searchPath: "foo=bar",
+  });
+
+  const { result } = renderHook(() => useSearch(), {
+    wrapper: (props) => {
+      return <Router searchHook={searchHook}>{props.children}</Router>;
+    },
+  });
+
+  expect(result.current).toEqual("key=value&foo=bar");
+});
+
 it("unescapes search string", () => {
   const { result: searchResult } = renderHook(() => useSearch());
 

--- a/packages/wouter/types/memory-location.d.ts
+++ b/packages/wouter/types/memory-location.d.ts
@@ -1,20 +1,22 @@
-import { BaseLocationHook, Path } from "./location-hook.js";
+import { BaseLocationHook, BaseSearchHook, Path, SearchString } from "./location-hook.js";
 
 type Navigate<S = any> = (
   to: Path,
   options?: { replace?: boolean; state?: S }
 ) => void;
 
-type HookReturnValue = { hook: BaseLocationHook; navigate: Navigate };
+type HookReturnValue = { hook: BaseLocationHook; searchHook: BaseSearchHook, navigate: Navigate };
 type StubHistory = { history: Path[]; reset: () => void };
 
 export function memoryLocation(options?: {
   path?: Path;
+  searchPath?: SearchString;
   static?: boolean;
   record?: false;
 }): HookReturnValue;
 export function memoryLocation(options?: {
   path?: Path;
+  searchPath?: SearchString;
   static?: boolean;
   record: true;
 }): HookReturnValue & StubHistory;

--- a/packages/wouter/types/memory-location.d.ts
+++ b/packages/wouter/types/memory-location.d.ts
@@ -1,11 +1,20 @@
-import { BaseLocationHook, BaseSearchHook, Path, SearchString } from "./location-hook.js";
+import {
+  BaseLocationHook,
+  BaseSearchHook,
+  Path,
+  SearchString,
+} from "./location-hook.js";
 
 type Navigate<S = any> = (
   to: Path,
   options?: { replace?: boolean; state?: S }
 ) => void;
 
-type HookReturnValue = { hook: BaseLocationHook; searchHook: BaseSearchHook, navigate: Navigate };
+type HookReturnValue = {
+  hook: BaseLocationHook;
+  searchHook: BaseSearchHook;
+  navigate: Navigate;
+};
 type StubHistory = { history: Path[]; reset: () => void };
 
 export function memoryLocation(options?: {


### PR DESCRIPTION
Return `searchHook` from `memoryLocation`. This can be passed to `Router`.

fixes #447 