### PR TITLE
fix(readme): typo in function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,12 +248,12 @@ By default, it uses `useBrowserLocation` under the hood, though you can configur
 import { useLocation } from "wouter";
 
 const CurrentLocation = () => {
-  const [location, setLocation] = useLocation();
+  const [location, navigate] = useLocation();
 
   return (
     <div>
       {`The current page is: ${location}`}
-      <a onClick={() => setLocation("/somewhere")}>Click to update</a>
+      <a onClick={() => navigate("/somewhere")}>Click to update</a>
     </div>
   );
 };


### PR DESCRIPTION
The readme section above the updated code fragment says that location changes are applied by calling `navigate`. However, in the code, the function was named `setLocation`. This PR renames `setLocation` to `navigate` in the example for better clarity.
(Generally, I would prefer `navigate` over `setLocation`. `setLocation` could be misunderstood as a state setter, whereas `navigate` is more specific by pointing out the side effect. This is just an opinion. :-))