### PR TITLE
feat: support `options.replace` in hash router

### DIFF
--- a/packages/wouter-preact/types/use-hash-location.d.ts
+++ b/packages/wouter-preact/types/use-hash-location.d.ts
@@ -1,6 +1,9 @@
 import { Path } from "./location-hook.js";
 
-export function navigate<S = any>(to: Path, options?: { state: S }): void;
+export function navigate<S = any>(
+  to: Path,
+  options?: { state?: S; replace?: boolean }
+): void;
 
 export function useHashLocation(options?: {
   ssrPath?: Path;

--- a/packages/wouter/src/use-hash-location.js
+++ b/packages/wouter/src/use-hash-location.js
@@ -27,8 +27,8 @@ export const navigate = (to, { state = null, replace = false } = {}) => {
 
   const newRelativePath =
     location.pathname + (search ? `?${search}` : location.search) + `#/${hash}`;
-  const oldURL = new URL(window.location.href);
-  const newURL = new URL(newRelativePath, window.location.origin);
+  const oldURL = window.location.href;
+  const newURL = new URL(newRelativePath, window.location.origin).href;
 
   if (replace) {
     history.replaceState(state, "", newRelativePath);

--- a/packages/wouter/src/use-hash-location.js
+++ b/packages/wouter/src/use-hash-location.js
@@ -23,40 +23,25 @@ const subscribeToHashUpdates = (callback) => {
 const currentHashLocation = () => "/" + location.hash.replace(/^#?\/?/, "");
 
 export const navigate = (to, { state = null, replace = false } = {}) => {
-  // calling `replaceState` allows us to set the history
-  // state without creating an extra entry
   const [hash, search] = to.replace(/^#?\/?/, "").split("?");
 
+  const newRelativePath =
+    location.pathname + (search ? `?${search}` : location.search) + `#/${hash}`;
+  const oldURL = new URL(window.location.href);
+  const newURL = new URL(newRelativePath, window.location.origin);
+
   if (replace) {
-    history.replaceState(
-      state,
-      "",
-      // keep the current pathname, but replace query string and hash
-      location.pathname +
-        (search ? `?${search}` : location.search) +
-        `#/${hash}`
-    );
-
-    const event =
-      typeof HashChangeEvent !== "undefined"
-        ? new HashChangeEvent("hashchange")
-        : new Event("hashchange");
-
-    dispatchEvent(event);
-
-    return;
+    history.replaceState(state, "", newRelativePath);
+  } else {
+    history.pushState(state, "", newRelativePath);
   }
 
-  history.replaceState(
-    state,
-    "",
-    // keep the current pathname, but replace query string and hash
-    location.pathname +
-      (search ? `?${search}` : location.search) +
-      // update location hash, this will cause `hashchange` event to fire
-      // normalise the value before updating, so it's always preceeded with "#/"
-      (location.hash = `#/${hash}`)
-  );
+  const event =
+    typeof HashChangeEvent !== "undefined"
+      ? new HashChangeEvent("hashchange", { oldURL, newURL })
+      : new Event("hashchange", { detail: { oldURL, newURL } });
+
+  dispatchEvent(event);
 };
 
 export const useHashLocation = ({ ssrPath = "/" } = {}) => [

--- a/packages/wouter/src/use-hash-location.js
+++ b/packages/wouter/src/use-hash-location.js
@@ -27,8 +27,8 @@ export const navigate = (to, { state = null, replace = false } = {}) => {
 
   const newRelativePath =
     location.pathname + (search ? `?${search}` : location.search) + `#/${hash}`;
-  const oldURL = window.location.href;
-  const newURL = new URL(newRelativePath, window.location.origin).href;
+  const oldURL = location.href;
+  const newURL = new URL(newRelativePath, location.origin).href;
 
   if (replace) {
     history.replaceState(state, "", newRelativePath);

--- a/packages/wouter/src/use-hash-location.js
+++ b/packages/wouter/src/use-hash-location.js
@@ -22,10 +22,30 @@ const subscribeToHashUpdates = (callback) => {
 // leading '#' is ignored, leading '/' is optional
 const currentHashLocation = () => "/" + location.hash.replace(/^#?\/?/, "");
 
-export const navigate = (to, { state = null } = {}) => {
+export const navigate = (to, { state = null, replace = false } = {}) => {
   // calling `replaceState` allows us to set the history
   // state without creating an extra entry
   const [hash, search] = to.replace(/^#?\/?/, "").split("?");
+
+  if (replace) {
+    history.replaceState(
+      state,
+      "",
+      // keep the current pathname, but replace query string and hash
+      location.pathname +
+        (search ? `?${search}` : location.search) +
+        `#/${hash}`
+    );
+
+    const event =
+      typeof HashChangeEvent !== "undefined"
+        ? new HashChangeEvent("hashchange")
+        : new Event("hashchange");
+
+    dispatchEvent(event);
+
+    return;
+  }
 
   history.replaceState(
     state,

--- a/packages/wouter/test/use-hash-location.test.tsx
+++ b/packages/wouter/test/use-hash-location.test.tsx
@@ -1,4 +1,4 @@
-import { it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach, vi } from "vitest";
 import { renderHook, render } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -207,4 +207,46 @@ it("defines a custom way of rendering link hrefs", () => {
   );
 
   expect(getByTestId("link")).toHaveAttribute("href", "#/app");
+});
+
+it("interacts properly with the history stack", () => {
+  const { result } = renderHook(() => useHashLocation());
+  const [, navigate] = result.current;
+
+  // case: replace, expect no history stack changes
+  const historyStackCountBeforeReplace = history.length;
+  navigate("/app/users", { replace: true });
+  expect(location.hash).toBe("#/app/users");
+  expect(history.length).toBe(historyStackCountBeforeReplace);
+
+  // case: push, expect history stack increase by 1
+  const historyStackCountBeforePush = history.length;
+  navigate("/app/users/2");
+  expect(location.hash).toBe("#/app/users/2");
+  expect(history.length).toBe(historyStackCountBeforePush + 1);
+});
+
+it("dispatches hashchange event when options.replace is true", () => {
+  const { result } = renderHook(() => useHashLocation());
+  const [, navigate] = result.current;
+
+  const hashChangeFn = vi.fn();
+  addEventListener("hashchange", hashChangeFn);
+
+  navigate("/foo/bar", { replace: true });
+  expect(hashChangeFn).toBeCalled();
+
+  removeEventListener("hashchange", hashChangeFn);
+});
+
+it("detects history change when navigate with options.replace is called", async () => {
+  const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  const { result } = renderHook(() => useHashLocation());
+  const [, navigate] = result.current;
+
+  const newPath = "/foo/bar/baz";
+  navigate(newPath, { replace: true });
+  await nextTick();
+  expect(result.current[0]).toBe(newPath);
 });

--- a/packages/wouter/test/use-hash-location.test.tsx
+++ b/packages/wouter/test/use-hash-location.test.tsx
@@ -251,7 +251,7 @@ it("detects history change when navigate with options.replace is called", async 
   expect(result.current[0]).toBe(newPath);
 });
 
-it("dispatches hashchange event when options.replace is true", () => {
+it("uses string URLs as hashchange event payload", () => {
   const { result } = renderHook(() => useHashLocation());
   const [, navigate] = result.current;
 

--- a/packages/wouter/test/use-hash-location.test.tsx
+++ b/packages/wouter/test/use-hash-location.test.tsx
@@ -250,3 +250,27 @@ it("detects history change when navigate with options.replace is called", async 
   await nextTick();
   expect(result.current[0]).toBe(newPath);
 });
+
+it("dispatches hashchange event when options.replace is true", () => {
+  const { result } = renderHook(() => useHashLocation());
+  const [, navigate] = result.current;
+
+  const relativeOldPath = "/foo";
+  const relativeNewPath = "/foo/bar/#hash";
+  const baseURL = "http://localhost:3000/#";
+
+  navigate(relativeOldPath);
+
+  let changeEvent = new HashChangeEvent("hashchange");
+  const hashChangeFn = (event: HashChangeEvent) => {
+    changeEvent = event;
+  };
+
+  addEventListener("hashchange", hashChangeFn);
+
+  navigate(relativeNewPath);
+  expect(changeEvent?.newURL).toBe(`${baseURL}${relativeNewPath}`);
+  expect(changeEvent?.oldURL).toBe(`${baseURL}${relativeOldPath}`);
+
+  removeEventListener("hashchange", hashChangeFn);
+});

--- a/packages/wouter/types/use-hash-location.d.ts
+++ b/packages/wouter/types/use-hash-location.d.ts
@@ -1,6 +1,9 @@
 import { Path } from "./location-hook.js";
 
-export function navigate<S = any>(to: Path, options?: { state: S }): void;
+export function navigate<S = any>(
+  to: Path,
+  options?: { state?: S; replace?: boolean }
+): void;
 
 export function useHashLocation(options?: {
   ssrPath?: Path;


### PR DESCRIPTION
This update adds support for path replacement in the hash router using options.replace, resolving the issue referenced in https://github.com/molefrog/wouter/issues/522