### PR TITLE
Update README.md for memoryLocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,10 +918,10 @@ import { memoryLocation } from "wouter/memory-location";
 it("renders a user page", () => {
   // `static` option makes it immutable
   // even if you call `navigate` somewhere in the app location won't change
-  const { hook } = memoryLocation({ path: "/user/2", static: true });
+  const { hook, searchHook } = memoryLocation({ path: "/user/2", static: true });
 
   const { container } = render(
-    <Router hook={hook}>
+    <Router hook={hook} searchHook={searchHook}>
       <Route path="/user/:id">{(params) => <>User ID: {params.id}</>}</Route>
     </Router>
   );


### PR DESCRIPTION
related: https://github.com/molefrog/wouter/issues/447

If you use `useSearch` without specifying `searchHook` while using `memoryLocation`, an error will occur.
Although I understand that specifying `searchHook` is unnecessary in cases where `useSearch` is not used, I believe it would be better to include `searchHook` by default in usage examples to avoid unnecessary confusion for first-time users.