### PR TITLE
rexport dependencies

### DIFF
--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -28,10 +28,11 @@ import { absolutePath, relativePath, sanitizeSearch } from "./paths.js";
  * via the <Router /> component.
  */
 
-const defaultRouter = {
+export const defaultParser = parsePattern;
+export const defaultRouter = {
   hook: useBrowserLocation,
   searchHook: useBrowserSearch,
-  parser: parsePattern,
+  parser: defaultParser,
   base: "",
   // this option is used to override the current location during SSR
   ssrPath: undefined,

--- a/packages/wouter/types/router.d.ts
+++ b/packages/wouter/types/router.d.ts
@@ -41,3 +41,6 @@ export type RouterOptions = {
   ssrContext?: SsrContext;
   hrefs?: HrefsFormatter;
 };
+
+export const defaultParser: Parser;
+export const defaultRouter: RouterObject;


### PR DESCRIPTION
there's no way to use the default parser outside of `useRouter()`. this PR exposes it