### PR TITLE
fix: resolve SSR hydration mismatch when ssrPath/ssrSearch not provided

### DIFF
--- a/packages/wouter/src/use-browser-location.js
+++ b/packages/wouter/src/use-browser-location.js
@@ -30,15 +30,18 @@ export const useLocationProperty = (fn, ssrFn) =>
 
 const currentSearch = () => location.search;
 
-export const useSearch = ({ ssrSearch = "" } = {}) =>
-  useLocationProperty(currentSearch, () => ssrSearch);
+export const useSearch = ({ ssrSearch } = {}) =>
+  useLocationProperty(
+    currentSearch,
+    ssrSearch != null ? () => ssrSearch : currentSearch
+  );
 
 const currentPathname = () => location.pathname;
 
 export const usePathname = ({ ssrPath } = {}) =>
   useLocationProperty(
     currentPathname,
-    ssrPath ? () => ssrPath : currentPathname
+    ssrPath != null ? () => ssrPath : currentPathname
   );
 
 const currentHistoryState = () => history.state;


### PR DESCRIPTION
Fixes #446

  When `ssrPath`/`ssrSearch` props are not provided during client-side hydration, use
  `location.pathname` and `location.search` as the SSR snapshot instead of defaulting to
  empty strings. This ensures hydration matches the server-rendered output.