### PR TITLE
Fix useSearch ssr regression

### DIFF
--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -146,9 +146,12 @@ export const Router = ({ children, ...props }) => {
   // holds to the context value: the router object
   let value = parent;
 
-  // when `ssrPath` contains a `?` character, we can extract the search from it
-  const [path, search] = props.ssrPath?.split("?") ?? [];
-  if (search) (props.ssrSearch = search), (props.ssrPath = path);
+  // when `ssrPath` contains a `?` character, we can extract the search from it.
+  // also, ensure ssrSearch is always defined when ssrPath is provided, so that
+  // useSearch behavior matches usePathname (proper SSR hydration when client
+  // renders <Router> without props after server rendered with ssrPath/ssrSearch)
+  const [path, search = props.ssrSearch ?? ""] = props.ssrPath?.split("?") ?? [];
+  if (path) props.ssrSearch = search, props.ssrPath = path;
 
   // hooks can define their own `href` formatter (e.g. for hash location)
   props.hrefs = props.hrefs ?? props.hook?.hrefs;

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -174,8 +174,8 @@ export const Router = ({ children, ...props }) => {
     const option =
       k === "base"
         ? /* base is special case, it is appended to the parent's base */
-          parent[k] + (props[k] || "")
-        : props[k] || parent[k];
+          parent[k] + (props[k] ?? "")
+        : props[k] ?? parent[k];
 
     if (prev === next && option !== next[k]) {
       ref.current = next = { ...next };

--- a/packages/wouter/src/use-browser-location.js
+++ b/packages/wouter/src/use-browser-location.js
@@ -33,7 +33,10 @@ const currentSearch = () => location.search;
 export const useSearch = ({ ssrSearch } = {}) =>
   useLocationProperty(
     currentSearch,
-    ssrSearch != null ? () => ssrSearch : () => ""
+    // != null checks for both null and undefined, but allows empty string ""
+    // This allows proper hydration: server renders with ssrSearch="?foo",
+    // client hydrates with just <Router /> and reads from location.search
+    ssrSearch != null ? () => ssrSearch : currentSearch
   );
 
 const currentPathname = () => location.pathname;
@@ -41,6 +44,9 @@ const currentPathname = () => location.pathname;
 export const usePathname = ({ ssrPath } = {}) =>
   useLocationProperty(
     currentPathname,
+    // != null checks for both null and undefined, but allows empty string ""
+    // This allows proper hydration: server renders with ssrPath="/foo",
+    // client hydrates with just <Router /> and reads from location.pathname
     ssrPath != null ? () => ssrPath : currentPathname
   );
 

--- a/packages/wouter/src/use-browser-location.js
+++ b/packages/wouter/src/use-browser-location.js
@@ -33,7 +33,7 @@ const currentSearch = () => location.search;
 export const useSearch = ({ ssrSearch } = {}) =>
   useLocationProperty(
     currentSearch,
-    ssrSearch != null ? () => ssrSearch : currentSearch
+    ssrSearch != null ? () => ssrSearch : () => ""
   );
 
 const currentPathname = () => location.pathname;

--- a/packages/wouter/test/router.test.tsx
+++ b/packages/wouter/test/router.test.tsx
@@ -76,7 +76,7 @@ it("can extract `ssrSearch` from `ssrPath` after the '?' symbol", () => {
   });
 
   expect(result.current.ssrPath).toBe("/no-search");
-  expect(result.current.ssrSearch).toBe(undefined);
+  expect(result.current.ssrSearch).toBe("");
 
   ssrPath = "/with-search?a=b&c=d";
   rerender();

--- a/packages/wouter/test/router.test.tsx
+++ b/packages/wouter/test/router.test.tsx
@@ -89,6 +89,15 @@ it("can extract `ssrSearch` from `ssrPath` after the '?' symbol", () => {
   expect(result.current.ssrSearch).toBe("a=b&c=d");
 });
 
+it("keeps the ssrSearch undefined if not in SSR mode", () => {
+  const { result } = renderHook(() => useRouter(), {
+    wrapper: (props) => <Router>{props.children}</Router>,
+  });
+
+  expect(result.current.ssrPath).toBe(undefined);
+  expect(result.current.ssrSearch).toBe(undefined);
+});
+
 it("shares one router instance between components", () => {
   const routers: any[] = [];
 

--- a/packages/wouter/test/setup.ts
+++ b/packages/wouter/test/setup.ts
@@ -11,3 +11,18 @@ GlobalRegistrator.register({
 
 // Extend Bun's expect with jest-dom matchers
 (expect as any).extend(matchers);
+
+/**
+ * Runs a function with `location` temporarily removed from globalThis.
+ * Simulates pure Node.js SSR environment for testing.
+ */
+export const withoutLocation = <T>(fn: () => T): T => {
+  const original = globalThis.location;
+  // @ts-expect-error - intentionally removing location
+  delete globalThis.location;
+  try {
+    return fn();
+  } finally {
+    globalThis.location = original;
+  }
+};

--- a/packages/wouter/test/ssr.test.tsx
+++ b/packages/wouter/test/ssr.test.tsx
@@ -110,8 +110,7 @@ describe("server-side rendering", () => {
       expect(rendered).toBe("/catalog filter by sort=created_at");
     });
 
-    // issue #550: useSearch should work in pure Node.js without `location` global
-    test("works without location global (issue #550)", () => {
+    test("doesn't break useSearch hook if not specified", () => {
       const PrintSearch = () => <>{useSearch()}</>;
 
       const rendered = withoutLocation(() =>
@@ -125,8 +124,7 @@ describe("server-side rendering", () => {
       expect(rendered).toBe("");
     });
 
-    // issue #550: passing ssrSearch="" explicitly should work
-    test("empty ssrSearch is respected (issue #550)", () => {
+    test("works with empty ssrSearch", () => {
       const PrintSearch = () => <>{useSearch()}</>;
 
       const rendered = withoutLocation(() =>

--- a/packages/wouter/test/ssr.test.tsx
+++ b/packages/wouter/test/ssr.test.tsx
@@ -10,6 +10,7 @@ import {
   useLocation,
   SsrContext,
 } from "../src/index.js";
+import { withoutLocation } from "./setup.js";
 
 describe("server-side rendering", () => {
   test("works via `ssrPath` prop", () => {
@@ -88,18 +89,6 @@ describe("server-side rendering", () => {
   });
 
   describe("rendering with given search string", () => {
-    test("is empty when not specified", () => {
-      const PrintSearch = () => <>{useSearch()}</>;
-
-      const rendered = renderToStaticMarkup(
-        <Router ssrPath="/">
-          <PrintSearch />
-        </Router>
-      );
-
-      expect(rendered).toBe("");
-    });
-
     test("allows to override search string", () => {
       const App = () => {
         const search = useSearch();
@@ -119,6 +108,36 @@ describe("server-side rendering", () => {
       );
 
       expect(rendered).toBe("/catalog filter by sort=created_at");
+    });
+
+    // issue #550: useSearch should work in pure Node.js without `location` global
+    test("works without location global (issue #550)", () => {
+      const PrintSearch = () => <>{useSearch()}</>;
+
+      const rendered = withoutLocation(() =>
+        renderToStaticMarkup(
+          <Router ssrPath="/">
+            <PrintSearch />
+          </Router>
+        )
+      );
+
+      expect(rendered).toBe("");
+    });
+
+    // issue #550: passing ssrSearch="" explicitly should work
+    test("empty ssrSearch is respected (issue #550)", () => {
+      const PrintSearch = () => <>{useSearch()}</>;
+
+      const rendered = withoutLocation(() =>
+        renderToStaticMarkup(
+          <Router ssrPath="/" ssrSearch="">
+            <PrintSearch />
+          </Router>
+        )
+      );
+
+      expect(rendered).toBe("");
     });
   });
 });


### PR DESCRIPTION
Fixes #550 - resolves SSR regression where `useSearch()` crashes in Node.js environments and ensures proper hydration when client renders `<Router>` without SSR props.