### PR TITLE
feat(memory-location): add initial location state support

### DIFF
--- a/packages/wouter-preact/types/memory-location.d.ts
+++ b/packages/wouter-preact/types/memory-location.d.ts
@@ -5,16 +5,22 @@ type Navigate<S = any> = (
   options?: { replace?: boolean; state?: S; transition?: boolean }
 ) => void;
 
-type HookReturnValue = { hook: BaseLocationHook; navigate: Navigate };
+type HookReturnValue<S = unknown> = {
+  hook: BaseLocationHook;
+  navigate: Navigate<S>;
+  readonly state: S | null;
+};
 type StubHistory = { history: Path[]; reset: () => void };
 
-export function memoryLocation(options?: {
+export function memoryLocation<S = unknown>(options?: {
   path?: Path;
+  state?: S;
   static?: boolean;
   record?: false;
-}): HookReturnValue;
-export function memoryLocation(options?: {
+}): HookReturnValue<S>;
+export function memoryLocation<S = unknown>(options?: {
   path?: Path;
+  state?: S;
   static?: boolean;
   record: true;
-}): HookReturnValue & StubHistory;
+}): HookReturnValue<S> & StubHistory;

--- a/packages/wouter/src/memory-location.js
+++ b/packages/wouter/src/memory-location.js
@@ -8,10 +8,12 @@ import { useSyncExternalStore } from "./react-deps.js";
 export const memoryLocation = ({
   path = "/",
   searchPath = "",
+  state = null,
   static: staticLocation,
   record,
 } = {}) => {
   let initialPath = path;
+  const initialState = state;
   if (searchPath) {
     // join with & if path contains search query, and ? otherwise
     initialPath += path.split("?")[1] ? "&" : "?";
@@ -19,10 +21,11 @@ export const memoryLocation = ({
   }
 
   let [currentPath, currentSearch = ""] = initialPath.split("?");
+  let currentState = initialState;
   const history = [initialPath];
   const emitter = mitt();
 
-  const navigateImplementation = (path, { replace = false } = {}) => {
+  const navigateImplementation = (path, { replace = false, state } = {}) => {
     if (record) {
       if (replace) {
         history.splice(history.length - 1, 1, path);
@@ -32,6 +35,7 @@ export const memoryLocation = ({
     }
 
     [currentPath, currentSearch = ""] = path.split("?");
+    if (state !== undefined) currentState = state;
     emitter.emit("navigate", path);
   };
 
@@ -56,15 +60,21 @@ export const memoryLocation = ({
   function reset() {
     // clean history array with mutation to preserve link
     history.splice(0, history.length);
-
-    navigateImplementation(initialPath);
+    navigateImplementation(initialPath, { state: initialState });
   }
 
-  return {
+  const memoryLocationResult = {
     hook: useMemoryLocation,
     searchHook: useMemoryQuery,
     navigate,
     history: record ? history : undefined,
     reset: record ? reset : undefined,
   };
+
+  Object.defineProperty(memoryLocationResult, "state", {
+    enumerable: true,
+    get: () => currentState,
+  });
+
+  return memoryLocationResult;
 };

--- a/packages/wouter/test/memory-location.test-d.ts
+++ b/packages/wouter/test/memory-location.test-d.ts
@@ -41,6 +41,15 @@ test("should support initial path", () => {
   expectTypeOf(hook).toMatchTypeOf<BaseLocationHook>();
 });
 
+test("should support state", () => {
+  const memory = memoryLocation({
+    path: "/initial-path",
+    state: { from: "test" },
+  });
+
+  expectTypeOf(memory.state).toEqualTypeOf<{ from: string } | null>();
+});
+
 test("should support `static` option", () => {
   const { hook } = memoryLocation({ static: true });
 

--- a/packages/wouter/test/memory-location.test.ts
+++ b/packages/wouter/test/memory-location.test.ts
@@ -23,6 +23,15 @@ test("should support initial path", () => {
   unmount();
 });
 
+test("should support initial state", () => {
+  const memory = memoryLocation({
+    path: "/test-case",
+    state: { from: "test" },
+  });
+
+  expect(memory.state).toStrictEqual({ from: "test" });
+});
+
 test("should support initial path with query", () => {
   const { searchHook } = memoryLocation({ path: "/test-case?foo=bar" });
 
@@ -78,6 +87,28 @@ test("should return standalone `navigate` method", () => {
   unmount();
 });
 
+test("should update state through standalone `navigate`", () => {
+  const memory = memoryLocation({
+    path: "/test-case",
+    state: { from: "test" },
+  });
+
+  memory.navigate("/standalone", { state: { from: "navigate" } });
+
+  expect(memory.state).toStrictEqual({ from: "navigate" });
+});
+
+test("should preserve state when navigating without `state` option", () => {
+  const memory = memoryLocation({
+    path: "/test-case",
+    state: { from: "test" },
+  });
+
+  memory.navigate("/standalone");
+
+  expect(memory.state).toStrictEqual({ from: "test" });
+});
+
 test("should return location hook that supports navigation", () => {
   const { hook } = memoryLocation();
 
@@ -87,6 +118,20 @@ test("should return location hook that supports navigation", () => {
 
   const [value] = result.current;
   expect(value).toBe("/location");
+  unmount();
+});
+
+test("should update state through hook navigation", () => {
+  const memory = memoryLocation({
+    path: "/test-case",
+    state: { from: "test" },
+  });
+
+  const { result, unmount } = renderHook(() => memory.hook());
+
+  act(() => result.current[1]("/location", { state: { from: "hook" } }));
+
+  expect(memory.state).toStrictEqual({ from: "hook" });
   unmount();
 });
 
@@ -160,4 +205,19 @@ test("should have reset method that reset hook location", () => {
   expect(result.current[0]).toBe("/test");
 
   unmount();
+});
+
+test("should reset state to its initial value", () => {
+  const memory = memoryLocation({
+    record: true,
+    path: "/test",
+    state: { from: "initial" },
+  });
+
+  memory.navigate("/location", { state: { from: "navigate" } });
+  expect(memory.state).toStrictEqual({ from: "navigate" });
+
+  memory.reset();
+
+  expect(memory.state).toStrictEqual({ from: "initial" });
 });

--- a/packages/wouter/types/memory-location.d.ts
+++ b/packages/wouter/types/memory-location.d.ts
@@ -10,22 +10,25 @@ type Navigate<S = any> = (
   options?: { replace?: boolean; state?: S; transition?: boolean }
 ) => void;
 
-type HookReturnValue = {
+type HookReturnValue<S = unknown> = {
   hook: BaseLocationHook;
   searchHook: BaseSearchHook;
-  navigate: Navigate;
+  navigate: Navigate<S>;
+  readonly state: S | null;
 };
 type StubHistory = { history: Path[]; reset: () => void };
 
-export function memoryLocation(options?: {
+export function memoryLocation<S = unknown>(options?: {
   path?: Path;
   searchPath?: SearchString;
+  state?: S;
   static?: boolean;
   record?: false;
-}): HookReturnValue;
-export function memoryLocation(options?: {
+}): HookReturnValue<S>;
+export function memoryLocation<S = unknown>(options?: {
   path?: Path;
   searchPath?: SearchString;
+  state?: S;
   static?: boolean;
   record: true;
-}): HookReturnValue & StubHistory;
+}): HookReturnValue<S> & StubHistory;


### PR DESCRIPTION
## Summary

Adds initial state support to memoryLocation, so tests and custom in-memory routing setups can seed the current location state and read it back from the returned object.

This change keeps the API small:

  - memoryLocation({ path, state }) now accepts an initial state
  - navigate(..., { state }) updates that state
  - the current value is exposed as memory.state

The value is intentionally exposed on the memoryLocation(...) result object rather than as a destructured snapshot, so it always reflects the latest navigation state.

  ## Changes

  - added state option to `memoryLocation`
  - stored and updated current in-memory location state alongside path/search
  - made `reset()` restore the initial state as well as the initial path
  - updated TypeScript declarations for both `wouter` and `wouter-preact`
  - added runtime and type coverage for the new API

  ## Testing

  - bun test packages/wouter/test/memory-location.test.ts
  - bun test-types

  Closes #492