### PR TITLE
Avoid URLSearchParams.size

### DIFF
--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -231,10 +231,8 @@ export function useSearchParams() {
     tempSearchParams = new URLSearchParams(
       typeof nextInit === "function" ? nextInit(tempSearchParams) : nextInit
     );
-    navigate(
-      location + (tempSearchParams.size ? "?" + tempSearchParams : ""),
-      options
-    );
+    const paramsStr = tempSearchParams.toString();
+    navigate(location + (paramsStr ? "?" + paramsStr : ""), options);
   });
 
   return [searchParams, setSearchParams];


### PR DESCRIPTION
Browsers gained support for it only in 2023. See [Browser compatibility on MDN](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/size#browser_compatibility).