### PR TITLE
Add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /packages/wouter-preact
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /packages/magazin
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /packages/wouter
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add Dependabot configuration to automate dependency updates for all npm packages and GitHub Actions.

The repo has four npm package directories (`/`, `/packages/wouter`, `/packages/wouter-preact`, `/packages/magazin`) and GitHub Actions workflows with pinned third-party actions — none currently have automated update coverage. This adds weekly grouped updates for each, reducing manual dependency maintenance while keeping PR noise low.

---

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.
