### PR TITLE
Fix routing edge cases and clarify navigation behavior

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -12,8 +12,6 @@ jobs:
           bun-version: latest
       - name: Install Dependencies
         run: bun install --frozen-lockfile
-      - name: Prepare wouter-preact (copy source files)
-        run: cd packages/wouter-preact && npm run prepublishOnly
       - name: Symlink npm to bun
         run: |
           sudo ln -sf $(which bun) /usr/local/bin/npm
@@ -22,4 +20,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           skip_step: install
-          build_script: build
+          # Run after each checkout so the base comparison uses its own sources.
+          build_script: --cwd packages/wouter-preact prepublishOnly

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Checks if the current location matches the pattern provided and returns an objec
 
 You can use `useRoute` to perform manual routing or implement custom logic, such as route transitions, etc.
 
+Patterns are relative to the current router's base. To match the full path from inside a nested router, prefix a string pattern with `~`: `useRoute("~/app/users/:id")`. This reads from the configured location hook, so it also works with hash and memory routing. The `~` prefix is handled by `useRoute`; use base-relative patterns for `Route` and `Switch`.
+
 ```js
 import { useRoute } from "wouter";
 
@@ -443,7 +445,7 @@ const App = () => (
 
 ### `<Route path={pattern} />`
 
-`Route` represents a piece of the app that is rendered conditionally based on a pattern `path`. Pattern has the same syntax as the argument you pass to [`useRoute`](#useroute-route-matching-and-parameters).
+`Route` represents a piece of the app that is rendered conditionally based on a pattern `path`. Patterns use the matching syntax described under [`useRoute`](#useroute-route-matching-and-parameters) and are relative to the current router's base.
 
 The library provides multiple ways to declare a route's body:
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ const App = () => (
 );
 ```
 
+With `useHashLocation`, navigating to `/about` preserves the current search parameters. Include a query to replace them (`/about?tab=1`), or an explicit empty query to clear them (`/about?`). This also works with `Link` and keeps search parameters before the hash in the browser URL.
+
 Because these hooks have return values similar to `useState`, it is easy and fun to build your own location hooks: `useCrossTabLocation`, `useLocalStorage`, `useMicroFrontendLocation` and whatever routing logic you want to support in the app. Give it a try!
 
 ### `useParams`: extracting matched parameters

--- a/README.md
+++ b/README.md
@@ -865,6 +865,8 @@ More complex examples involve using `useRoutes` hook (similar to how React Route
 
 Wouter works seamlessly with the [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API), but you'll need to manually activate it. This is because view transitions require synchronous DOM rendering and must be wrapped in `flushSync` from `react-dom`. Following wouter's philosophy of staying lightweight and avoiding unnecessary dependencies, view transitions aren't built-in. However, there's a simple escape hatch to enable them: the `aroundNav` prop.
 
+This recipe uses the browser's `document.startViewTransition` API. React's [`<ViewTransition>` component](https://react.dev/reference/react/ViewTransition) has different requirements: the default location hook uses `useSyncExternalStore`, whose updates [cannot be marked as React transitions](https://react.dev/reference/react/useSyncExternalStore#caveats). Wrapping `navigate` in `startTransition` therefore does not enable React `<ViewTransition>` animations for these route updates.
+
 ```jsx
 import { flushSync } from "react-dom";
 import { Router, type AroundNavHandler } from "wouter";

--- a/README.md
+++ b/README.md
@@ -525,6 +525,8 @@ import { Link } from "wouter"
 
 Link will always wrap its children in an `<a />` tag, unless `asChild` prop is provided. Use this when you need to have a custom component that renders an `<a />` under the hood.
 
+With `asChild`, attributes such as `className`, `style`, and `aria-label` are forwarded to the child. Props supplied to `Link` override the child's corresponding props; omitted props are preserved. A `className` function receives the same active flag as a regular link. In React, `Link` also forwards its ref; with `wouter-preact`, place the ref on the child.
+
 ```jsx
 // use this instead
 <Link to="/" asChild>

--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ return (
 
 If a trailing slash is important for your app's routing, you could specify a custom parser. Parser is a method that takes a pattern string and returns a RegExp and an array of parsed key. It uses the signature of a [`parse`](https://github.com/lukeed/regexparam?tab=readme-ov-file#regexparamparseinput-regexp) function from `regexparam`.
 
-Let's write a custom parser based on a popular [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp) package that does support strict routes option.
+The example below requires [`path-to-regexp` v6](https://github.com/pillarjs/path-to-regexp/tree/v6.3.0), which supports the `strict` option and the three-argument `pathToRegexp` API used here. Install it with `bun add path-to-regexp@6`. Version 8 uses a different API.
 
 ```js
 import { pathToRegexp } from "path-to-regexp";

--- a/README.md
+++ b/README.md
@@ -642,7 +642,9 @@ available options:
 
 - `hrefs: (href: boolean) => string` — a function for transforming `href` attribute of an `<a />` element rendered by `Link`. It is used to support hash-based routing. By default, `href` attribute is the same as the `href` or `to` prop of a `Link`. A location hook can also define a `hook.hrefs` property, in this case the `href` will be inferred.
 
-- **`aroundNav: (navigate, to, options) => void`** — a handler that wraps all navigation calls. Use this to intercept navigation and perform custom logic before and after the navigation occurs. You can modify navigation parameters, add side effects, or prevent navigation entirely. This is particularly useful for implementing [view transitions](#how-do-i-add-view-transitions-to-my-app). By default, it simply calls `navigate(to, options)`.
+- **`aroundNav: (navigate, to, options) => void`** — a handler that wraps navigation through `useLocation`, including `Link` and `Redirect`. Use it to modify navigation parameters, add side effects, or cancel a navigation by not calling `navigate`. This is particularly useful for implementing [view transitions](#how-do-i-use-wouter-with-view-transitions-api). By default, it calls `navigate(to, options)`.
+
+  Browser Back/Forward navigation, direct History API calls, and calls to the low-level `navigate` exported from `wouter/use-browser-location` bypass this handler.
 
   ```js
   const aroundNav = (navigate, to, options) => {

--- a/packages/wouter-preact/src/react-deps.js
+++ b/packages/wouter-preact/src/react-deps.js
@@ -61,7 +61,8 @@ export function useSyncExternalStore(subscribe, getSnapshot, getSSRSnapshot) {
 
 // provide forwardRef stub for preact
 export function forwardRef(component) {
-  return component;
+  // Preact passes legacy context as the second argument, not a forwarded ref.
+  return (props) => component(props);
 }
 
 // Userland polyfill while we wait for the forthcoming

--- a/packages/wouter-preact/test/preact.test.tsx
+++ b/packages/wouter-preact/test/preact.test.tsx
@@ -66,6 +66,42 @@ describe("Preact support", () => {
     teardown();
   });
 
+  test("asChild forwards props and preserves the child's ref (#536)", async () => {
+    const { Link, Router } = await loadPreact();
+    const container = document.body.appendChild(document.createElement("div"));
+    const childRef = mock();
+    try {
+      act(() => {
+        render(
+          <Router base="/app">
+            <Link
+              href="/about"
+              asChild
+              className="parent"
+              style={{ color: "red" }}
+              aria-label="About us"
+            >
+              <a ref={childRef} className="child" title="Child title">
+                About
+              </a>
+            </Link>
+          </Router>,
+          container
+        );
+      });
+      const link = container.querySelector("a")!;
+      expect(link.getAttribute("href")).toBe("/app/about");
+      expect(link.className).toBe("parent");
+      expect(link.style.color).toBe("red");
+      expect(link.getAttribute("aria-label")).toBe("About us");
+      expect(link.title).toBe("Child title");
+      expect(childRef).toHaveBeenCalledWith(link);
+    } finally {
+      act(() => render(null, container));
+      container.remove();
+    }
+  });
+
   describe("useRoute", () => {
     test("should only accept strings", async () => {
       const { useRoute } = await loadPreact();

--- a/packages/wouter-preact/types/index.d.ts
+++ b/packages/wouter-preact/types/index.d.ts
@@ -112,7 +112,10 @@ type HTMLLinkAttributes = Omit<JSX.HTMLAttributes, "className"> & {
 export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> =
   NavigationalProps<H> &
     AsChildProps<
-      { children: ComponentChildren; onClick?: JSX.MouseEventHandler<Element> },
+      Omit<HTMLLinkAttributes, "onClick" | "ref"> & {
+        children: ComponentChildren;
+        onClick?: JSX.MouseEventHandler<Element>;
+      },
       HTMLLinkAttributes
     >;
 

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -115,7 +115,7 @@ export const matchRoute = (parser, route, path, loose) => {
 
 export const useRoute = (pattern) => {
   const router = useRouter();
-  const absolute = typeof pattern === "string" && pattern.startsWith("~/");
+  const absolute = /^~\//.test(pattern);
   return matchRoute(
     router.parser,
     absolute ? pattern.slice(1) : pattern,
@@ -267,10 +267,10 @@ export const Link = forwardRef((props, ref) => {
     transition /* ignore nav props */,
     /* eslint-enable no-unused-vars */
 
-    ...restProps
+    ...linkProps
   } = props;
 
-  const onClick = useEvent((event) => {
+  linkProps.onClick = useEvent((event) => {
     // ignores the navigation when clicked using right mouse button or
     // by holding a special modifier key: ctrl, command, win, alt, shift
     if (
@@ -290,12 +290,11 @@ export const Link = forwardRef((props, ref) => {
   });
 
   // handle nested routers and absolute paths
-  const href = router.hrefs(
+  linkProps.href = router.hrefs(
     targetPath[0] === "~" ? targetPath.slice(1) : router.base + targetPath,
     router // pass router as a second argument for convinience
   );
 
-  const linkProps = { ...restProps, onClick, href };
   // Omitted props should preserve the child's own className and ref.
   if (cls !== undefined)
     linkProps.className = cls?.call ? cls(currentPath === targetPath) : cls;
@@ -303,7 +302,7 @@ export const Link = forwardRef((props, ref) => {
 
   return asChild && isValidElement(children)
     ? cloneElement(children, linkProps)
-    : h("a", { ...linkProps, children });
+    : h("a", linkProps, children);
 });
 
 const flattenChildren = (children, result = []) => {

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -290,17 +290,15 @@ export const Link = forwardRef((props, ref) => {
     router // pass router as a second argument for convinience
   );
 
+  const linkProps = { ...restProps, onClick, href };
+  // Omitted props should preserve the child's own className and ref.
+  if (cls !== undefined)
+    linkProps.className = cls?.call ? cls(currentPath === targetPath) : cls;
+  if (ref) linkProps.ref = ref;
+
   return asChild && isValidElement(children)
-    ? cloneElement(children, { onClick, href })
-    : h("a", {
-        ...restProps,
-        onClick,
-        href,
-        // `className` can be a function to apply the class if this link is active
-        className: cls?.call ? cls(currentPath === targetPath) : cls,
-        children,
-        ref,
-      });
+    ? cloneElement(children, linkProps)
+    : h("a", { ...linkProps, children });
 });
 
 const flattenChildren = (children, result = []) => {

--- a/packages/wouter/src/index.js
+++ b/packages/wouter/src/index.js
@@ -65,8 +65,8 @@ export const useParams = () => useContext(ParamsCtx);
 
 // Internal location hooks avoid redundant context reads and navigation callbacks.
 
-const usePathnameFromRouter = (router) =>
-  relativePath(router.base, router.hook(router)[0]);
+const usePathnameFromRouter = (router, base = router.base) =>
+  relativePath(base, router.hook(router)[0]);
 
 const useLocationFromRouter = (router) => {
   const [location, navigate] = router.hook(router);
@@ -115,7 +115,12 @@ export const matchRoute = (parser, route, path, loose) => {
 
 export const useRoute = (pattern) => {
   const router = useRouter();
-  return matchRoute(router.parser, pattern, usePathnameFromRouter(router));
+  const absolute = typeof pattern === "string" && pattern.startsWith("~/");
+  return matchRoute(
+    router.parser,
+    absolute ? pattern.slice(1) : pattern,
+    usePathnameFromRouter(router, absolute ? "" : router.base)
+  );
 };
 
 /*

--- a/packages/wouter/src/use-browser-location.js
+++ b/packages/wouter/src/use-browser-location.js
@@ -14,14 +14,19 @@ const events = [
   eventHashchange,
 ];
 
+let listeners = [];
+const onLocationChange = () => listeners.forEach((callback) => callback());
+
+// Native events can run microtasks between listeners. Notify all subscribers
+// together so React can process parent and child updates in the same batch.
 const subscribeToLocationUpdates = (callback) => {
-  for (const event of events) {
-    addEventListener(event, callback);
-  }
+  if (listeners.push(callback) === 1)
+    for (const event of events) addEventListener(event, onLocationChange);
+
   return () => {
-    for (const event of events) {
-      removeEventListener(event, callback);
-    }
+    listeners = listeners.filter((listener) => listener !== callback);
+    if (!listeners.length)
+      for (const event of events) removeEventListener(event, onLocationChange);
   };
 };
 

--- a/packages/wouter/src/use-browser-location.js
+++ b/packages/wouter/src/use-browser-location.js
@@ -3,16 +3,7 @@ import { useSyncExternalStore } from "./react-deps.js";
 /**
  * History API docs @see https://developer.mozilla.org/en-US/docs/Web/API/History
  */
-const eventPopstate = "popstate";
-const eventPushState = "pushState";
-const eventReplaceState = "replaceState";
-const eventHashchange = "hashchange";
-const events = [
-  eventPopstate,
-  eventPushState,
-  eventReplaceState,
-  eventHashchange,
-];
+const events = ["popstate", "pushState", "replaceState", "hashchange"];
 
 let listeners = [];
 const onLocationChange = () => listeners.forEach((callback) => callback());
@@ -21,12 +12,12 @@ const onLocationChange = () => listeners.forEach((callback) => callback());
 // together so React can process parent and child updates in the same batch.
 const subscribeToLocationUpdates = (callback) => {
   if (listeners.push(callback) === 1)
-    for (const event of events) addEventListener(event, onLocationChange);
+    events.forEach((event) => addEventListener(event, onLocationChange));
 
   return () => {
     listeners = listeners.filter((listener) => listener !== callback);
     if (!listeners.length)
-      for (const event of events) removeEventListener(event, onLocationChange);
+      events.forEach((event) => removeEventListener(event, onLocationChange));
   };
 };
 
@@ -60,7 +51,7 @@ export const useHistoryState = () =>
   useLocationProperty(currentHistoryState, () => null);
 
 export const navigate = (to, { replace = false, state = null } = {}) =>
-  history[replace ? eventReplaceState : eventPushState](state, "", to);
+  history[replace ? "replaceState" : "pushState"](state, "", to);
 
 // the 2nd argument of the `useBrowserLocation` return value is a function
 // that allows to perform a navigation.
@@ -74,7 +65,7 @@ const patchKey = Symbol.for("wouter_v3");
 //
 // See https://stackoverflow.com/a/4585031
 if (typeof history !== "undefined" && typeof window[patchKey] === "undefined") {
-  for (const type of [eventPushState, eventReplaceState]) {
+  for (const type of ["pushState", "replaceState"]) {
     const original = history[type];
     // TODO: we should be using unstable_batchedUpdates to avoid multiple re-renders,
     // however that will require an additional peer dependency on react-dom.

--- a/packages/wouter/src/use-hash-location.js
+++ b/packages/wouter/src/use-hash-location.js
@@ -29,7 +29,7 @@ export const navigate = (to, { state = null, replace = false } = {}) => {
   // Works for ALL protocols including data:
   const url = new URL(oldURL);
   url.hash = `/${hash}`;
-  if (search) url.search = search;
+  if (search !== undefined) url.search = search;
   const newURL = url.href;
 
   history[replace ? "replaceState" : "pushState"](state, "", newURL);

--- a/packages/wouter/test/browser-navigation.test.tsx
+++ b/packages/wouter/test/browser-navigation.test.tsx
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+import { act, render } from "@testing-library/react";
+import { ReactNode, useEffect, useSyncExternalStore } from "react";
+import { Route, Switch, useRoute } from "../src/index.js";
+
+test("keeps Switch children consistent across native popstate listeners", () => {
+  const eventName = "popstate";
+  // Native browser events can run a microtask between listeners. Stop the
+  // event after the child subscribes to reproduce a render before Switch
+  // receives the update, which synchronous dispatchEvent otherwise hides.
+  const subscribe = (callback: () => void) => {
+    const listener = (event: Event) => {
+      event.stopImmediatePropagation();
+      callback();
+    };
+    addEventListener(eventName, listener);
+    return () => removeEventListener(eventName, listener);
+  };
+
+  const InterruptEvent = ({ children }: { children: ReactNode }) => {
+    useSyncExternalStore(subscribe, () => true);
+    return <>{children}</>;
+  };
+
+  const renders: string[] = [];
+  const effects: string[] = [];
+  const Detail = () => {
+    const [, params] = useRoute("/characters/:id");
+    renders.push(params!.id);
+    useEffect(() => {
+      effects.push(params!.id);
+    });
+    return null;
+  };
+
+  history.replaceState(null, "", "/characters/new");
+  history.pushState(null, "", "/characters/123");
+
+  const { container } = render(
+    <Switch>
+      <Route path="/characters/new">New character</Route>
+      <Route path="/characters/:id">
+        <InterruptEvent>
+          <Detail />
+        </InterruptEvent>
+      </Route>
+    </Switch>
+  );
+
+  act(() => {
+    history.back();
+    dispatchEvent(new Event(eventName));
+  });
+
+  expect(renders).toEqual(["123"]);
+  expect(effects).toEqual(["123"]);
+  expect(container).toHaveTextContent("New character");
+});

--- a/packages/wouter/test/link.test-d.tsx
+++ b/packages/wouter/test/link.test-d.tsx
@@ -130,13 +130,11 @@ describe("<Link /> with `asChild` prop", () => {
     </Link>;
   });
 
-  test("does not allow other props", () => {
-    // @ts-expect-error
+  test("accepts forwarded attributes and refs", () => {
     <Link to="/" asChild className="">
       <a>Hello</a>
     </Link>;
 
-    // @ts-expect-error
     <Link to="/" asChild style={{}}>
       <a>Hello</a>
     </Link>;
@@ -146,9 +144,17 @@ describe("<Link /> with `asChild` prop", () => {
       <a>Hello</a>
     </Link>;
 
-    // @ts-expect-error
     <Link to="/" asChild ref={null}>
       <a>Hello</a>
+    </Link>;
+
+    <Link
+      to="/"
+      asChild
+      ref={React.createRef<HTMLButtonElement>()}
+      className={(active) => (active ? "active" : undefined)}
+    >
+      <button>Hello</button>
     </Link>;
   });
 

--- a/packages/wouter/test/link.test.tsx
+++ b/packages/wouter/test/link.test.tsx
@@ -255,6 +255,76 @@ describe("active links", () => {
 });
 
 describe("<Link /> with `asChild` prop", () => {
+  test("forwards attributes, styles, events and ref to its child (#536)", () => {
+    const ref = mock<(element: HTMLAnchorElement) => void>();
+    const onFocus = mock();
+    const { getByRole } = render(
+      <Link
+        href="/about"
+        asChild
+        className="parent-class"
+        style={{ color: "red" }}
+        aria-label="About us"
+        data-tracking="about"
+        onFocus={onFocus}
+        ref={ref}
+        replace
+        state={{ source: "link" }}
+      >
+        <a className="child-class" title="Child title">
+          About
+        </a>
+      </Link>
+    );
+    const link = getByRole("link", { name: "About us" });
+    expect(link).toHaveClass("parent-class");
+    expect(link).not.toHaveClass("child-class");
+    expect(link).toHaveStyle({ color: "red" });
+    expect(link).toHaveAttribute("data-tracking", "about");
+    expect(link).toHaveAttribute("title", "Child title");
+    expect(link).not.toHaveAttribute("replace");
+    expect(link).not.toHaveAttribute("state");
+    expect(ref).toHaveBeenCalledWith(link);
+    fireEvent.focus(link);
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    fireEvent.click(link);
+    expect(location.pathname).toBe("/about");
+  });
+
+  test("preserves the child's className and ref when Link omits them", () => {
+    const childRef = mock<(element: HTMLAnchorElement) => void>();
+    const { getByText } = render(
+      <Link href="/about" asChild>
+        <a ref={childRef} className="child-class">
+          About
+        </a>
+      </Link>
+    );
+    const link = getByText("About");
+    expect(link).toHaveClass("child-class");
+    expect(childRef).toHaveBeenCalledWith(link);
+  });
+
+  test("updates the child's active className after navigation", () => {
+    const { hook, navigate } = memoryLocation({ path: "/about" });
+    const { getByText } = render(
+      <Router hook={hook}>
+        <Link
+          href="/about"
+          asChild
+          className={(active) => (active ? "active" : undefined)}
+        >
+          <a className="child-class">About</a>
+        </Link>
+      </Router>
+    );
+    const link = getByText("About");
+    expect(link).toHaveClass("active");
+    act(() => navigate("/other"));
+    expect(link).not.toHaveClass("active");
+    expect(link).not.toHaveClass("child-class");
+  });
+
   test("when `asChild` is not specified, wraps the children in an <a />", () => {
     const { getByText } = render(
       <Link href="/about">

--- a/packages/wouter/test/use-hash-location.test.tsx
+++ b/packages/wouter/test/use-hash-location.test.tsx
@@ -1,5 +1,5 @@
 import { test, expect, mock } from "bun:test";
-import { renderHook, render, act } from "@testing-library/react";
+import { renderHook, render, act, fireEvent } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { Router, Route, useLocation, Link } from "../src/index.js";
@@ -90,18 +90,55 @@ test("changes search and hash when contains ? symbol", () => {
   expect(location.hash).toBe("#/abc");
 });
 
-test("preserves the search for an empty query and ignores extra query segments", () => {
-  history.replaceState(null, "", "/foo?original#/app");
+test.each([false, true])(
+  "clears the search for an explicit empty query (replace: %s)",
+  (replace) => {
+    history.replaceState(null, "", "/foo?original#/app");
+    const initialLength = history.length;
+    const state = { source: "clear-search" };
+    const { result } = renderHook(() => useHashLocation());
+    const [, navigate] = result.current;
+
+    act(() => navigate("#/empty?", { replace, state }));
+
+    expect(location.pathname).toBe("/foo");
+    expect(location.hash).toBe("#/empty");
+    expect(location.search).toBe("");
+    expect(result.current[0]).toBe("/empty");
+    expect(history.state).toEqual(state);
+    expect(history.length).toBe(initialLength + (replace ? 0 : 1));
+  }
+);
+
+test("ignores extra query segments", () => {
   const { result } = renderHook(() => useHashLocation());
   const [, navigate] = result.current;
-
-  act(() => navigate("#/empty?"));
-  expect(location.hash).toBe("#/empty");
-  expect(location.search).toBe("?original");
-
   act(() => navigate("/next?first?ignored"));
   expect(location.hash).toBe("#/next");
   expect(location.search).toBe("?first");
+});
+
+test("Link can explicitly clear search parameters with hash routing (#473)", () => {
+  history.replaceState(null, "", "/foo?original#/app");
+  const initialLength = history.length;
+  const state = { source: "clear-search-link" };
+  const { getByText } = render(
+    <Router hook={useHashLocation}>
+      <Link href="/next?" replace state={state}>
+        Clear search
+      </Link>
+      <Route path="/next">Next page</Route>
+    </Router>
+  );
+
+  fireEvent.click(getByText("Clear search"));
+
+  expect(location.pathname).toBe("/foo");
+  expect(location.hash).toBe("#/next");
+  expect(location.search).toBe("");
+  expect(history.state).toEqual(state);
+  expect(history.length).toBe(initialLength);
+  expect(getByText("Next page")).toBeInTheDocument();
 });
 
 test("creates a new history entry when navigating", () => {

--- a/packages/wouter/test/use-route.test-d.ts
+++ b/packages/wouter/test/use-route.test-d.ts
@@ -51,3 +51,15 @@ test("infers parameters from the route path", () => {
     }>();
   }
 });
+
+test("infers parameters from absolute route patterns", () => {
+  const [match, params] = useRoute("~/app/users/:name?/:id");
+
+  if (match) {
+    expectTypeOf(params.id).toEqualTypeOf<string>();
+    expectTypeOf(params.name).toEqualTypeOf<string | undefined>();
+    expectTypeOf(params[0]).toEqualTypeOf<string | undefined>();
+  } else {
+    expectTypeOf(params).toEqualTypeOf<null>();
+  }
+});

--- a/packages/wouter/test/use-route.test.tsx
+++ b/packages/wouter/test/use-route.test.tsx
@@ -160,6 +160,58 @@ it("supports regex patterns", () => {
   assertRoute(/[/](?<param>[a-z]+)/, "/123", false);
 });
 
+it("matches absolute patterns without a base (#244)", () => {
+  assertRoute("~/users/:id", "/users/12", { 0: "12", id: "12" });
+  assertRoute("~/", "/", {});
+  assertRoute("~/users/:id", "/other/12", false);
+  assertRoute("/~user", "/~user", {});
+  assertRoute("~user", "/~user", {});
+  assertRoute("~", "/~", {});
+});
+
+it.each([
+  ["/app/team/users/12", "~/app/team/users/:id"],
+  ["/app/users/12", "~/app/users/:id"],
+  ["/other/users/12", "~/other/users/:id"],
+] as const)(
+  "matches absolute patterns across nested bases at %s",
+  (path, pattern) => {
+    const { result } = renderHook(() => useRoute(pattern), {
+      wrapper: (props) => (
+        <Router hook={memoryLocation({ path, static: true }).hook} base="/app">
+          <Router base="/team" {...props} />
+        </Router>
+      ),
+    });
+
+    expect(result.current).toStrictEqual([true, { 0: "12", id: "12" }]);
+  }
+);
+
+it("switches between relative, absolute and regex patterns", () => {
+  const { hook, navigate } = memoryLocation({ path: "/app/users/12" });
+  const { result, rerender } = renderHook(
+    ({ pattern }: { pattern: string | RegExp }) => useRoute(pattern),
+    {
+      initialProps: { pattern: "/users/:id" as string | RegExp },
+      wrapper: (props) => <Router hook={hook} base="/app" {...props} />,
+    }
+  );
+
+  expect(result.current).toStrictEqual([true, { 0: "12", id: "12" }]);
+  rerender({ pattern: "~/app/users/:id" });
+  expect(result.current).toStrictEqual([true, { 0: "12", id: "12" }]);
+  rerender({ pattern: /^\/users\/(?<id>[^/]+)$/ });
+  expect(result.current).toStrictEqual([true, { 0: "12", id: "12" }]);
+
+  act(() => navigate("/outside/users/34"));
+  expect(result.current).toStrictEqual([false, null]);
+  rerender({ pattern: "~/outside/users/:id" });
+  expect(result.current).toStrictEqual([true, { 0: "34", id: "34" }]);
+  act(() => navigate("/outside/users/56"));
+  expect(result.current).toStrictEqual([true, { 0: "56", id: "56" }]);
+});
+
 it("reacts to pattern updates", () => {
   const { result, rerender } = renderHook(
     ({ pattern }: { pattern: string }) => useRoute(pattern),

--- a/packages/wouter/types/index.d.ts
+++ b/packages/wouter/types/index.d.ts
@@ -130,7 +130,11 @@ type HTMLLinkAttributes = Omit<
 export type LinkProps<H extends BaseLocationHook = BrowserLocationHook> =
   NavigationalProps<H> &
     AsChildProps<
-      { children: ReactElement; onClick?: MouseEventHandler },
+      Omit<HTMLLinkAttributes, "onClick"> &
+        RefAttributes<HTMLElement> & {
+          children: ReactElement;
+          onClick?: MouseEventHandler;
+        },
       HTMLLinkAttributes & RefAttributes<HTMLAnchorElement>
     >;
 


### PR DESCRIPTION
Fix routing edge cases found while reviewing all 27 open issues. Each issue's change has its own commit; existing hash-navigation defaults, URL decoding, and public navigation signatures are preserved.

### Changes

- **#536:** Forward `Link asChild` attributes, styles, active classes, and React refs. Preserve omitted child props and Preact child refs; update both packages' types.
- **#556:** Notify browser-location subscribers together so native Back/Forward cannot render a stale child route before its `Switch` updates. Also reproduces and resolves the overlapping-route case in #464.
- **#473:** Allow an explicit `/route?` to clear hash-router search parameters. `/route` still preserves them. This addresses query clearing, not the historical URL-format migration.
- **#244:** Let `useRoute("~/...")` match against the full location inside nested bases. Relative patterns and regular expressions retain their behavior.
- **#452:** Correct the documented scope of `aroundNav`: browser Back/Forward and low-level navigation bypass it.
- **#559:** Explain why the browser View Transitions recipe does not enable React `<ViewTransition>` animations.
- **#563:** Specify the v6 dependency required by the strict-parser recipe; this does not add URLPattern support.
- Reduce bundle overhead from the fixes, and prepare Preact sources after each checkout in the size-limit workflow so both revisions are measured correctly.

### Validation

- `bun test --coverage`: **243 passed, 1 existing skip, 0 failed; 100% line coverage** (13 more tests than the baseline).
- `bun run test-types`, `bun run lint`, and the repository build script passed. Local lint reports four pre-existing warnings in ignored generated bundles.
- All eight size limits pass; React entry 2,341 B / 2,500 B, Preact entry 2,230 B / 2,500 B.
- Independent review found no remaining actionable issues.

The native-history fix was also checked in real Chrome against a failing control. New runtime regressions were demonstrated before their fixes. The parser recipe was executed with its documented dependency API.

### Size optimization

Reuse Link's rest-props object, pass children directly to `createElement`, simplify the absolute-pattern check, and shorten browser event registration. These retain the new behavior while reducing bundle size. No limits, ignored dependencies, or measurement settings were relaxed.

Size-limit results in minified Brotli bytes:

| Entry | Base branch | Before optimization | Final |
| --- | ---: | ---: | ---: |
| React router | 2,264 | 2,373 | 2,341 |
| React browser location | 522 | 565 | 555 |
| React memory location | 733 | 733 | 733 |
| React hash location | 718 | 720 | 720 |
| Preact router | 2,159 | 2,273 | 2,230 |
| Preact browser location | 457 | 507 | 488 |
| Preact memory location | 671 | 671 | 671 |
| Preact hash location | 640 | 645 | 645 |

The previous CI comparison reused generated Preact files from the PR when measuring the base branch. The size workflow now regenerates them after each checkout; the table uses independently prepared sources for every revision. The remaining increase pays for the new fixes, particularly grouped history notifications and absolute route matching.

<details>
<summary>Remaining issues reviewed</summary>

- **#565:** Incomplete application/stack trace; cannot establish whether it shares #556's cause.
- **#560:** Exact Preact 10.28.4 passes isolated browser and hash navigation; no application reproduction was supplied.
- **#542:** Basic hash links pass; the linked sandbox could not be retrieved.
- **#528, #493:** Changing search-preservation defaults or URL decoding would alter existing contracts.
- **#506:** React 17 promise navigation still reproduces and needs a separate batching solution.
- **#432:** Cross-component search updates still race; a general fix needs shared synchronization and external-navigation handling.
- **#498, #499:** Base-relative navigation/matching usage rather than a confirmed defect.
- **#562, #558, #552, #539, #517, #512, #511, #470, #467, #300:** New routing/history/parser/scroll behavior or existing extension points; no additional bounded fix identified.

Documentation-only and partial fixes above intentionally do not claim to implement the broader requested features.

</details>

Fixes #536
Fixes #556
Fixes #244
Refs #464, #473, #452, #559, #563
